### PR TITLE
Add Javadoc for REST file server data classes

### DIFF
--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/CatCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/CatCommand.java
@@ -17,7 +17,12 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 /**
- * Simple cat command for use with rest server
+ * Command that reads or writes a file on the REST file server.
+ * <p>
+ * When run without options the file identified by {@code path} is written to
+ * standard output. With {@code --create} or {@code --versioned} the command
+ * reads from standard input to create a new file.
+ *
  * @author tonyj
  */
 @Command(name = "cat", description = "Write the contents of a file to standard output")
@@ -41,7 +46,14 @@ public class CatCommand implements Callable<Void> {
     
     @Spec CommandSpec spec;
 
-    @Override   
+    @Override
+    /**
+     * Executes the cat command.
+     *
+     * @return {@code null} always
+     * @throws IOException if an I/O error occurs while reading or writing the
+     *         file
+     */
     public Void call() throws IOException {
         try (FileSystem restfs = parent.createFileSystem()) {
             Path restPath = restfs.getPath(path);

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/DiffCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/DiffCommand.java
@@ -17,7 +17,8 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 /**
- * Simple cat command for use with rest server
+ * Command that displays differences between two versions of a file on the
+ * REST file server.
  *
  * @author tonyj
  */
@@ -42,6 +43,12 @@ public class DiffCommand implements Callable<Void> {
     CommandSpec spec;
 
     @Override
+    /**
+     * Executes the diff command.
+     *
+     * @return {@code null} always
+     * @throws IOException if an I/O error occurs while generating the diff
+     */
     public Void call() throws IOException {
         try (FileSystem restfs = parent.createFileSystem()) {
             Path restPath = restfs.getPath(path);

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/EditCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/EditCommand.java
@@ -25,7 +25,8 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
- * Simple edit command for use with rest server
+ * Command that opens a remote file in an editor and writes back any
+ * modifications.
  *
  * @author tonyj
  */
@@ -45,6 +46,12 @@ public class EditCommand implements Callable<Void> {
     private String path;
 
     @Override
+    /**
+     * Executes the edit command.
+     *
+     * @return {@code null} always
+     * @throws Exception if an error occurs while editing or writing the file
+     */
     public Void call() throws Exception {
         try (FileSystem restfs = parent.createFileSystem()) {
             Path restPath = restfs.getPath(path);

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/FileDateFormatter.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/FileDateFormatter.java
@@ -7,7 +7,9 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 /**
- * A formatter for file date, tries to emulate ls
+ * Formats file modification times in a style similar to the Unix {@code ls}
+ * command.
+ *
  * @author tonyj
  */
 public class FileDateFormatter {
@@ -20,17 +22,29 @@ public class FileDateFormatter {
     private final Instant referenceTime;
 
     
+    /**
+     * Creates a formatter.
+     *
+     * @param fullTime if {@code true}, always use the full time format rather
+     *        than switching based on age
+     */
     FileDateFormatter(boolean fullTime) {
         this.fullTime = fullTime;
         referenceTime = Instant.now();
     }
-    
+
+    /**
+     * Formats the supplied file time.
+     *
+     * @param time the file time to format
+     * @return the formatted time string
+     */
     String format(FileTime time) {
         Instant timeStamp = time.toInstant();
         Duration age = Duration.between(referenceTime, timeStamp);
         DateTimeFormatter formatter;
         if (fullTime) {
-            formatter = FULL_FORMAT;  
+            formatter = FULL_FORMAT;
         } else if (age.compareTo(SWITCH_FORMAT_AGE)<0) {
             formatter = RECENT_FORMAT;  
         } else {

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/FileSizeFormatter.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/FileSizeFormatter.java
@@ -1,7 +1,8 @@
 package org.lsst.ccs.rest.file.server.cli;
 
 /**
- * A formatter for file size. tries to emulate ls
+ * Formats file sizes in a style similar to the Unix {@code ls} command.
+ *
  * @author tonyj
  */
 public class FileSizeFormatter {
@@ -9,14 +10,26 @@ public class FileSizeFormatter {
     private final boolean humanReadable;
     private final boolean si;
 
+    /**
+     * Creates a formatter.
+     *
+     * @param humanReadable whether to use human readable units
+     * @param si if {@code true}, use powers of 1000; otherwise use 1024
+     */
     FileSizeFormatter(boolean humanReadable, boolean si) {
         this.humanReadable = humanReadable;
         this.si = si;
     }
-    
+
+    /**
+     * Formats the supplied size.
+     *
+     * @param size the size in bytes
+     * @return a string representation of the size
+     */
     String format(long size) {
         if (humanReadable) {
-            return humanReadableByteCount(size, si); 
+            return humanReadableByteCount(size, si);
         } else {
             return String.format("%d", size);
         }

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/ListCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/ListCommand.java
@@ -18,7 +18,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
- * Simple ls command for use with rest server
+ * Command that lists files and directories on the REST file server.
  *
  * @author tonyj
  */
@@ -50,6 +50,12 @@ public class ListCommand implements Callable<Void> {
     private String path;
 
     @Override
+    /**
+     * Executes the ls command.
+     *
+     * @return {@code null} always
+     * @throws IOException if an I/O error occurs while listing
+     */
     public Void call() throws IOException {
         try (FileSystem restfs = parent.createFileSystem()) {
             Path restPath = restfs.getPath(path);

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/MakeDirectoryCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/MakeDirectoryCommand.java
@@ -11,7 +11,7 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
 
 /**
- * Simple mkdir command for use with rest server
+ * Command that creates directories on the REST file server.
  *
  * @author tonyj
  */
@@ -28,6 +28,12 @@ public class MakeDirectoryCommand implements Callable<Void> {
     private boolean createParents;
 
     @Override
+    /**
+     * Executes the mkdir command.
+     *
+     * @return {@code null} always
+     * @throws IOException if the directory cannot be created
+     */
     public Void call() throws IOException {
         try (FileSystem restfs = parent.createFileSystem()) {
             Path restPath = restfs.getPath(path);

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/MoveCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/MoveCommand.java
@@ -10,7 +10,7 @@ import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
 
 /**
- * Simple cat command for use with rest server
+ * Command that moves or renames a file or directory on the REST file server.
  *
  * @author tonyj
  */
@@ -27,6 +27,12 @@ public class MoveCommand implements Callable<Void> {
     private String to;
 
     @Override
+    /**
+     * Executes the move command.
+     *
+     * @return {@code null} always
+     * @throws IOException if an error occurs moving the file
+     */
     public Void call() throws IOException {
         try (FileSystem restfs = parent.createFileSystem()) {
             Path fromPath = restfs.getPath(from);

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/SetCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/SetCommand.java
@@ -16,7 +16,9 @@ import picocli.CommandLine.ParentCommand;
 import picocli.CommandLine.Spec;
 
 /**
- * Simple cat command for use with rest server
+ * Command that modifies attributes of a versioned file on the REST file
+ * server.
+ *
  * @author tonyj
  */
 @Command(name = "set", description = "Modify settings on a versioned file")
@@ -43,7 +45,13 @@ public class SetCommand implements Callable<Void> {
     
     @Spec CommandSpec spec;
 
-    @Override   
+    @Override
+    /**
+     * Executes the set command.
+     *
+     * @return {@code null} always
+     * @throws IOException if an I/O error occurs while updating the file
+     */
     public Void call() throws IOException {
         try (FileSystem restfs = parent.createFileSystem()) {
             Path restPath = restfs.getPath(path);

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/TopLevelCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/TopLevelCommand.java
@@ -14,7 +14,9 @@ import picocli.CommandLine.HelpCommand;
 import picocli.CommandLine.Option;
 
 /**
- * Top level command for running all other commands
+ * Entry point for the REST file server command line interface. This command
+ * configures the connection to the server and provides access to the various
+ * subcommands.
  *
  * @author tonyj
  */
@@ -50,12 +52,24 @@ public class TopLevelCommand {
 
     @Option(names = "--auth", description = "Provide (jwt) authorization token")
     private String authToken;
-    
+
+    /**
+     * Launches the command line interface.
+     *
+     * @param args command line arguments
+     */
     public static void main(String[] args) {
         int exitCode = new CommandLine(new TopLevelCommand()).execute(args);
         System.exit(exitCode);
     }
 
+    /**
+     * Creates a {@link FileSystem} for interacting with the REST file server
+     * using the configured options.
+     *
+     * @return a new file system instance
+     * @throws IOException if the file system cannot be created
+     */
     FileSystem createFileSystem() throws IOException {
         URI uri = URI.create(restServer);
         HashMap<String, Object> options = new HashMap<>();

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/Utils.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/Utils.java
@@ -9,11 +9,19 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
+ * Utility helpers for the command line interface.
  *
  * @author tonyj
  */
 class Utils {
 
+    /**
+     * Copies all bytes from an input stream to an output stream.
+     *
+     * @param in the source stream
+     * @param out the destination stream
+     * @throws IOException if an I/O error occurs during the copy
+     */
     static void copy(InputStream in, OutputStream out) throws IOException {
         byte[] buf = new byte[32768];
         for (;;) {
@@ -25,24 +33,43 @@ class Utils {
         }
     }
 
+    /**
+     * Creates a builder for an array of {@link OpenOption} values.
+     *
+     * @param options initial open options
+     * @return a new builder containing the provided options
+     */
     static OpenOptionsBuilder openOptionsBuilder(OpenOption... options) {
         return new OpenOptionsBuilder(options);
     }
 
+    /**
+     * Helper class for building arrays of {@link OpenOption} values.
+     */
     static class OpenOptionsBuilder {
         private final List<OpenOption> options;
 
         private OpenOptionsBuilder(OpenOption[] initialOptions) {
             options = new ArrayList<>(Arrays.asList(initialOptions));
         }
-        
+
+        /**
+         * Adds an option to the builder.
+         *
+         * @param option the option to add
+         */
         void add(OpenOption option) {
             options.add(option);
         }
-        
+
+        /**
+         * Builds the array of open options.
+         *
+         * @return the accumulated options
+         */
         OpenOption[] build() {
             return options.toArray(new OpenOption[options.size()]);
         }
     }
-    
+
 }

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/package-info.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Command line tools for interacting with the REST file server.
+ */
+package org.lsst.ccs.rest.file.server.cli;
+

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/RestFileSystemOptions.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/RestFileSystemOptions.java
@@ -32,78 +32,174 @@ public class RestFileSystemOptions {
      */
     public final static String DEFAULT_ENV_PROPERTY = "org.lsst.ccs.rest.file.client.defaultEnvironment";
 
+    /**
+     * Caching strategies for the client.
+     */
     public enum CacheOptions {
-        NONE, MEMORY_ONLY, MEMORY_AND_DISK
+        /** Do not cache any data locally. */
+        NONE,
+        /** Cache data in memory only. */
+        MEMORY_ONLY,
+        /** Cache data in memory and on disk. */
+        MEMORY_AND_DISK
     };
 
+    /**
+     * Fallback behavior when a cache cannot be accessed.
+     */
     public enum CacheFallback {
-        NEVER, OFFLINE, ALWAYS, WHEN_POSSIBLE;
+        /** Never fall back to an alternate cache location. */
+        NEVER,
+        /** Use the alternate cache only when offline. */
+        OFFLINE,
+        /** Always use the alternate cache if available. */
+        ALWAYS,
+        /** Use the alternate cache when possible. */
+        WHEN_POSSIBLE;
     };
-    
+
+    /**
+     * Control over use of SSL connections.
+     */
     public enum SSLOptions {
-        TRUE, FALSE, AUTO
+        /** Always use SSL. */
+        TRUE,
+        /** Never use SSL. */
+        FALSE,
+        /** Decide automatically based on URI scheme. */
+        AUTO
     };
-    
+
+    /**
+     * Creates a builder for assembling an environment map.
+     *
+     * @return a new builder instance
+     */
     public static Builder builder() {
         return new Builder();
     }
-    
+
+    /**
+     * Builder used to construct the environment map passed to
+     * {@code RestFileSystemProvider}.
+     */
     public static class Builder {
         private final Map<String, Object> map = new HashMap<>();
-        
+
+        /**
+         * Specifies the cache location using a {@link File} path.
+         *
+         * @param location directory where the cache should be stored
+         * @return this builder for method chaining
+         */
         public Builder cacheLocation(File location) {
             map.put(CACHE_LOCATION, location);
             return this;
         }
 
+        /**
+         * Specifies the cache location using a {@link Path}.
+         *
+         * @param location path where the cache should be stored
+         * @return this builder for method chaining
+         */
         public Builder cacheLocation(Path location) {
             map.put(CACHE_LOCATION, location);
             return this;
         }
-        
+
+        /**
+         * Enables or disables cache activity logging.
+         *
+         * @param log {@code true} to enable logging
+         * @return this builder for method chaining
+         */
         public Builder logging(boolean log) {
             map.put(CACHE_LOGGING, log);
             return this;
         }
 
+        /**
+         * Sets the caching strategy.
+         *
+         * @param option cache option to apply
+         * @return this builder for method chaining
+         */
         public Builder set(CacheOptions option) {
             map.put(CACHE_OPTIONS, option);
             return this;
         }
 
+        /**
+         * Sets the SSL usage option.
+         *
+         * @param option SSL option to apply
+         * @return this builder for method chaining
+         */
         public Builder set(SSLOptions option) {
             map.put(USE_SSL, option);
             return this;
         }
 
+        /**
+         * Sets the cache fallback behavior.
+         *
+         * @param option fallback option to use
+         * @return this builder for method chaining
+         */
         public Builder set(CacheFallback option) {
             map.put(CACHE_FALLBACK, option);
             return this;
         }
-        
+
+        /**
+         * Supplies an authorization token to be used with requests.
+         *
+         * @param token JWT authorization token
+         * @return this builder for method chaining
+         */
         public Builder setAuthorizationToken(String token) {
             map.put(AUTH_TOKEN, token);
             return this;
         }
-        
+
+        /**
+         * Allows the cache to fall back to an alternate location when locked.
+         *
+         * @param allow {@code true} to permit alternate cache locations
+         * @return this builder for method chaining
+         */
         public Builder ignoreLockedCache(boolean allow) {
             map.put(ALLOW_ALTERNATE_CACHE_LOCATION, allow);
-            return this;            
+            return this;
         }
 
+        /**
+         * Sets the mount point URI for the file system.
+         *
+         * @param mountPoint URI identifying the desired mount point
+         * @return this builder for method chaining
+         */
         public Builder mountPoint(URI mountPoint) {
             map.put(MOUNT_POINT, mountPoint);
-            return this;            
+            return this;
         }
-        
+
+        /**
+         * Builds the environment map containing all configured options.
+         *
+         * @return map of file system options
+         */
         public Map<String, Object> build() {
             return map;
         }
     }
+
     /**
-     * Provide a default environment to be used in the event that no explicit
-     * environment is given when creating the RestFileSystem.
-     * @param defaultEnv 
+     * Provide a default environment to be used when no explicit environment is
+     * supplied to the {@code newFileSystem} methods.
+     *
+     * @param defaultEnv map of default options
      */
     public static void setDefaultFileSystemEnvironment(Map<String, ?> defaultEnv) {
         RestFileSystemProvider.setDefaultFileSystemOption(defaultEnv);

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionOpenOption.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionOpenOption.java
@@ -9,7 +9,9 @@ import java.nio.file.OpenOption;
  */
 public class VersionOpenOption implements OpenOption {
 
+    /** Option representing the latest available version. */
     public static VersionOpenOption LATEST = new VersionOpenOption("latest");
+    /** Option representing the default version. */
     public static VersionOpenOption DEFAULT = new VersionOpenOption("default");
     private final String value;
 
@@ -17,14 +19,33 @@ public class VersionOpenOption implements OpenOption {
         this.value = version;
     }
 
+    /**
+     * Returns the string value representing this option.
+     *
+     * @return version token
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Creates an option referencing a specific version number.
+     *
+     * @param version explicit version number
+     * @return option representing the given version
+     */
     public static VersionOpenOption of(int version) {
         return new VersionOpenOption(String.valueOf(version));
     }
 
+    /**
+     * Parses a string into a {@code VersionOpenOption}.
+     * Recognizes {@code "latest"}, {@code "default"}, or a numeric version.
+     *
+     * @param version string representation of the version
+     * @return corresponding option instance
+     * @throws IllegalArgumentException if the string cannot be parsed
+     */
     public static VersionOpenOption of(String version) {
         if (LATEST.value.equals(version)) {
             return LATEST;
@@ -39,6 +60,12 @@ public class VersionOpenOption implements OpenOption {
         }
     }
 
+    /**
+     * Resolves the numeric version referenced by this option using file attributes.
+     *
+     * @param attributes attributes providing default and latest versions
+     * @return resolved integer version
+     */
     public int getIntVersion(VersionedFileAttributes attributes) {
         if (VersionOpenOption.LATEST.value.equals(value)) {
             return attributes.getLatestVersion();

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionedFileAttributeView.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionedFileAttributeView.java
@@ -10,11 +10,37 @@ import java.nio.file.attribute.FileAttributeView;
  */
 public interface VersionedFileAttributeView extends FileAttributeView {
 
+    /**
+     * Reads the extended versioned attributes for a file.
+     *
+     * @return file attributes including version information
+     * @throws IOException if the attributes cannot be read
+     */
     VersionedFileAttributes readAttributes() throws IOException;
 
+    /**
+     * Sets the default version for the file.
+     *
+     * @param version new default version number
+     * @throws IOException if the default version cannot be updated
+     */
     void setDefaultVersion(int version) throws IOException;
-    
+
+    /**
+     * Associates a comment with a specific version.
+     *
+     * @param version version number to annotate
+     * @param comment text to associate with the version
+     * @throws IOException if the comment cannot be saved
+     */
     void setComment(int version, String comment) throws IOException;
-    
+
+    /**
+     * Marks a specific version as hidden or visible.
+     *
+     * @param version version number to modify
+     * @param hidden {@code true} to hide the version
+     * @throws IOException if the hidden flag cannot be changed
+     */
     void setHidden(int version, boolean hidden) throws IOException;
 }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionedFileAttributes.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionedFileAttributes.java
@@ -3,20 +3,55 @@ package org.lsst.ccs.rest.file.server.client;
 import java.nio.file.attribute.BasicFileAttributes;
 
 /**
- * Extra file attributes associated with versioned files
+ * Extra file attributes associated with versioned files.
+ * Provides access to version metadata and per-version file attributes.
+ *
  * @author tonyj
  */
 public interface VersionedFileAttributes extends BasicFileAttributes {
 
+    /**
+     * Returns the list of version numbers available for the file.
+     *
+     * @return array of available version numbers
+     */
     int[] getVersions();
 
+    /**
+     * Gets the most recent version number available for the file.
+     *
+     * @return latest version number
+     */
     int getLatestVersion();
 
+    /**
+     * Gets the default version number for the file.
+     *
+     * @return default version number
+     */
     int getDefaultVersion();
-    
+
+    /**
+     * Checks whether a specific version is marked as hidden.
+     *
+     * @param version version number to test
+     * @return {@code true} if the version is hidden
+     */
     boolean isHidden(int version);
-    
+
+    /**
+     * Retrieves the comment associated with a given version.
+     *
+     * @param version version number for which to obtain the comment
+     * @return comment text or {@code null} if none exists
+     */
     String getComment(int version);
-    
+
+    /**
+     * Provides the basic file attributes for a particular version.
+     *
+     * @param version version number for which to retrieve attributes
+     * @return basic attributes of the specified version
+     */
     BasicFileAttributes getAttributes(int version);
 }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionedOpenOption.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/VersionedOpenOption.java
@@ -3,9 +3,11 @@ package org.lsst.ccs.rest.file.server.client;
 import java.nio.file.OpenOption;
 
 /**
- *Additional open options for use with versioned files
+ * Additional open options for use with versioned files.
+ *
  * @author tonyj
  */
 public enum VersionedOpenOption implements OpenOption {
-   DIFF // Open a version file diff
+   /** Open a version file diff. */
+   DIFF
 }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main.java
@@ -12,11 +12,18 @@ import java.util.List;
 import java.util.stream.Stream;
 
 /**
- *
- * @author tonyj
+ * Demonstrates basic read operations against a REST file server.
+ * The example connects to the server, locates a file and prints a few
+ * of its attributes and contents.
  */
 public class Main {
 
+    /**
+     * Runs the example.
+     *
+     * @param args ignored
+     * @throws IOException if an I/O error occurs while contacting the server
+     */
     public static void main(String[] args) throws IOException {
         URI uri = URI.create("ccs://lsst-camera-dev.slac.stanford.edu/RestFileServer/");
         FileSystem restfs = FileSystems.newFileSystem(uri, Collections.<String, Object>emptyMap());
@@ -42,7 +49,7 @@ public class Main {
         stream.forEach(path -> System.out.println(path.getFileName().toString()));
         
         BasicFileAttributeView fileAttributeView = Files.getFileAttributeView(pathInRestServer, BasicFileAttributeView.class);
-        
+
         //Map<String, Object> readAttributes = Files.readAttributes(pathInRestServer, "*");
     }
 

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main2.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main2.java
@@ -12,11 +12,17 @@ import java.util.Map;
 import org.lsst.ccs.rest.file.server.client.VersionedFileAttributeView;
 
 /**
- *
- * @author tonyj
+ * Example that prints file attributes from both a local file and a file on the
+ * REST file server.
  */
 public class Main2 {
 
+    /**
+     * Runs the example.
+     *
+     * @param args ignored
+     * @throws IOException if an error occurs while accessing either file system
+     */
     public static void main(String[] args) throws IOException {
         Path path = Paths.get("/home/tonyj/Untitled9.ipynb");
         Map<String, Object> readAttributes = Files.readAttributes(path, "*");

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main3.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main3.java
@@ -14,11 +14,17 @@ import org.lsst.ccs.rest.file.server.client.VersionOpenOption;
 import org.lsst.ccs.rest.file.server.client.VersionedFileAttributeView;
 
 /**
- *
- * @author tonyj
+ * Example showing how to read a specific version of a file using
+ * {@link VersionOpenOption}.
  */
 public class Main3 {
 
+    /**
+     * Runs the example.
+     *
+     * @param args ignored
+     * @throws IOException if the file cannot be read
+     */
     public static void main(String[] args) throws IOException {
         URI uri = URI.create("ccs://lsst-camera-dev.slac.stanford.edu/RestFileServer/");
         FileSystem restfs = FileSystems.newFileSystem(uri, Collections.<String, Object>emptyMap());

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main4.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/Main4.java
@@ -11,11 +11,16 @@ import java.util.Collections;
 import java.util.Properties;
 
 /**
- *
- * @author tonyj
+ * Example that uploads a new properties file to the REST file server.
  */
 public class Main4 {
 
+    /**
+     * Runs the example.
+     *
+     * @param args ignored
+     * @throws IOException if the upload fails
+     */
     public static void main(String[] args) throws IOException {
         URI uri = URI.create("ccs://lsst-camera-dev.slac.stanford.edu/RestFileServer/");
         FileSystem restfs = FileSystems.newFileSystem(uri, Collections.<String, Object>emptyMap());

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/package-info.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/examples/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Example programs demonstrating use of the REST file server client.
+ */
+package org.lsst.ccs.rest.file.server.client.examples;

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/AddJWTTokenRequestFilter.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/AddJWTTokenRequestFilter.java
@@ -6,13 +6,20 @@ import javax.ws.rs.client.ClientRequestFilter;
 import javax.ws.rs.core.HttpHeaders;
 
 /**
- *
- * @author tonyj
+ * {@link ClientRequestFilter} that adds a JSON Web Token (JWT) to each request
+ * so that the REST server can authenticate the client.
  */
 public class AddJWTTokenRequestFilter implements ClientRequestFilter {
     private static final String JWT_HEADER_KEY = HttpHeaders.AUTHORIZATION;
     private final String jwt;
 
+    /**
+     * Creates a new filter that attaches the supplied token as a bearer
+     * authorization header.
+     *
+     * @param jwt the JWT to include; may be {@code null} if no token is
+     *            available
+     */
     AddJWTTokenRequestFilter(String jwt) {
         this.jwt = jwt;
     }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/AddProtcolVersionRequestFilter.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/AddProtcolVersionRequestFilter.java
@@ -6,8 +6,8 @@ import javax.ws.rs.client.ClientRequestFilter;
 import static org.lsst.ccs.web.rest.file.server.data.Constants.PROTOCOL_VERSION_HEADER;
 
 /**
- *
- * @author tonyj
+ * {@link ClientRequestFilter} that informs the server which client protocol
+ * version is being used.
  */
 public class AddProtcolVersionRequestFilter implements ClientRequestFilter {
     private static final String FILTER_HEADER_VALUE = "2";

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
@@ -26,8 +26,9 @@ import org.apache.commons.jcs3.log.LogManager;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 
 /**
- *
- * @author tonyj
+ * Simple in-memory or disk-backed cache used to store server responses. The
+ * cache is optional and its behaviour is controlled by
+ * {@link RestFileSystemOptions}.
  */
 class Cache implements Closeable {
 
@@ -35,6 +36,12 @@ class Cache implements Closeable {
     private FileLock lock;
     private RestFileSystemOptions.CacheFallback cacheFallback;
 
+    /**
+     * Creates a new cache instance based on the supplied options.
+     *
+     * @param options user supplied configuration
+     * @throws IOException if the cache cannot be initialised
+     */
     Cache(RestFileSystemOptionsHelper options) throws IOException {
 
         JCS.setLogSystem(LogManager.LOGSYSTEM_JAVA_UTIL_LOGGING);
@@ -129,6 +136,9 @@ class Cache implements Closeable {
 
     }
 
+    /**
+     * Serializable representation of a cached HTTP response.
+     */
     public static class CacheEntry implements Serializable {
 
         private String tag;
@@ -140,6 +150,9 @@ class Cache implements Closeable {
 
         static final long serialVersionUID = 1521062449875932852L;
 
+        /**
+         * Creates an empty cache entry. Used only for serialization.
+         */
         public CacheEntry() {
 
         }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/CacheRequestFilter.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/CacheRequestFilter.java
@@ -20,10 +20,12 @@ class CacheRequestFilter implements ClientRequestFilter {
     private final boolean cacheOnly;
 
     /**
-     * Create a new CacheRequestFilter.
-     * @param cache The cache to use
-     * @param cacheOnly <code>true</code> if requests should be forced to come from the cache
-     * without checking their freshness, e.g. if the server is known to be offline.
+     * Creates a filter that serves requests from the local cache when
+     * possible.
+     *
+     * @param cache the backing cache
+     * @param cacheOnly {@code true} to avoid contacting the server and rely
+     *                  solely on cached data
      */
     CacheRequestFilter(Cache cache, boolean cacheOnly) {
         this.cache = cache;

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/CacheResponseFilter.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/CacheResponseFilter.java
@@ -18,6 +18,12 @@ class CacheResponseFilter implements ClientResponseFilter {
 
     private final Cache cache;
 
+    /**
+     * Creates a new response filter that updates the local cache with data
+     * returned from the server.
+     *
+     * @param cache the cache used to store responses
+     */
     CacheResponseFilter(Cache cache) {
         this.cache = cache;
     }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestClient.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestClient.java
@@ -50,8 +50,9 @@ import org.lsst.ccs.web.rest.file.server.data.VersionInfoV2;
 import org.lsst.ccs.web.rest.file.server.data.VersionOptions;
 
 /**
- *
- * @author tonyj
+ * Low level helper that performs HTTP requests against the REST file server.
+ * Instances are created by {@link RestFileSystem} and are not intended for
+ * external use.
  */
 class RestClient implements Closeable {
 
@@ -381,6 +382,11 @@ class RestClient implements Closeable {
     }
 
     @Override
+    /**
+     * Closes the underlying JAX-RS client and releases any system resources.
+     *
+     * @throws IOException if closing the client fails
+     */
     public void close() throws IOException {
         client.close();
     }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileAttributes.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileAttributes.java
@@ -5,58 +5,72 @@ import java.nio.file.attribute.FileTime;
 import org.lsst.ccs.web.rest.file.server.data.RestFileInfo;
 
 /**
- *
- * @author tonyj
+ * Implementation of {@link BasicFileAttributes} backed by
+ * {@link RestFileInfo} data retrieved from the REST service.
  */
 class RestFileAttributes implements BasicFileAttributes {
 
     private final RestFileInfo info;
     
+    /**
+     * Creates a new set of file attributes.
+     *
+     * @param info metadata describing the file; must not be {@code null}
+     */
     RestFileAttributes(RestFileInfo info) {
         if (info == null) throw new NullPointerException();
         this.info = info;
     }
-    
+
+    /** {@inheritDoc} */
     @Override
     public FileTime lastModifiedTime() {
         return FileTime.fromMillis(info.getLastModified());
     }
 
+    /** {@inheritDoc} */
     @Override
     public FileTime lastAccessTime() {
         return FileTime.fromMillis(info.getLastAccessTime());
     }
 
+    /** {@inheritDoc} */
     @Override
     public FileTime creationTime() {
         return FileTime.fromMillis(info.getCreationTime());
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isRegularFile() {
         return info.isRegularFile() && !info.isVersionedFile();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isDirectory() {
         return info.isDirectory();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isSymbolicLink() {
         return info.isSymbolicLink();
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isOther() {
         return info.isOther() || info.isVersionedFile();
     }
 
+    /** {@inheritDoc} */
     @Override
     public long size() {
         return info.getSize();
     }
 
+    /** {@inheritDoc} */
     @Override
     public Object fileKey() {
         return info.getFileKey();

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileStore.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileStore.java
@@ -7,27 +7,35 @@ import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileStoreAttributeView;
 
 /**
- *
- * @author tonyj
+ * {@link FileStore} representation for the REST file system. Most space related
+ * queries are not supported and will throw {@link UnsupportedOperationException}.
  */
 class RestFileStore extends FileStore {
 
     private final RestFileSystem fileSystem;
 
+    /**
+     * Creates a new file store backed by the given file system.
+     *
+     * @param fileSystem the owning file system
+     */
     RestFileStore(RestFileSystem fileSystem) {
         this.fileSystem = fileSystem;
     }
-    
+
+    /** {@inheritDoc} */
     @Override
     public String name() {
         return fileSystem.toString();
     }
 
+    /** {@inheritDoc} */
     @Override
     public String type() {
         return "ccs";
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isReadOnly() {
         return fileSystem.isReadOnly();
@@ -48,21 +56,25 @@ class RestFileStore extends FileStore {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
         return type.isAssignableFrom(BasicFileAttributeView.class) || type.isAssignableFrom(RestVersionedFileAttributes.class);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean supportsFileAttributeView(String name) {
         return fileSystem.supportedFileAttributeViews().contains(name);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <V extends FileStoreAttributeView> V getFileStoreAttributeView(Class<V> type) {
         return null;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Object getAttribute(String attribute) throws IOException {
         return null;

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
@@ -28,8 +28,8 @@ import org.lsst.ccs.rest.file.server.client.implementation.unixlike.AbstractPath
 import org.lsst.ccs.rest.file.server.client.implementation.unixlike.AbstractFileSystem;
 
 /**
- *
- * @author tonyj
+ * {@link java.nio.file.FileSystem} implementation that communicates with a
+ * remote REST file server.
  */
 public class RestFileSystem extends AbstractFileSystem implements AbstractPathBuilder {
 
@@ -49,6 +49,14 @@ public class RestFileSystem extends AbstractFileSystem implements AbstractPathBu
     private static final Logger LOG = Logger.getLogger(RestFileSystem.class.getName());
     private final URI mountPoint;
 
+    /**
+     * Creates a new REST-based file system.
+     *
+     * @param provider owning provider instance
+     * @param uri base URI of the REST server
+     * @param env configuration options controlling client behaviour
+     * @throws IOException if the system cannot be initialised
+     */
     public RestFileSystem(RestFileSystemProvider provider, URI uri, Map<String, ?> env) throws IOException {
         this.provider = provider;
         uri = uri.getPath().endsWith("/") ? uri : UriBuilder.fromUri(uri).path(uri.getPath()+"/").build();
@@ -172,6 +180,12 @@ public class RestFileSystem extends AbstractFileSystem implements AbstractPathBu
         return uri.resolve(path);
     }
     
+    /**
+     * Returns the URI path that is considered the root within the remote
+     * server.
+     *
+     * @return the mount point URI
+     */
     public URI getMountPoint() {
         return mountPoint;
     }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
@@ -14,8 +14,8 @@ import java.util.logging.Logger;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 
 /**
- *
- * @author tonyj
+ * Utility wrapper around the environment map supplied when creating the REST
+ * file system. Provides typed accessors for the various supported options.
  */
  class RestFileSystemOptionsHelper {
 
@@ -23,6 +23,11 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
     private static final Logger LOG = Logger.getLogger(RestFileSystemOptionsHelper.class.getName());
     private static final URI defaultMountPoint = URI.create(".");
 
+    /**
+     * Creates a new helper.
+     *
+     * @param env environment map supplied to the file system; may be {@code null}
+     */
     RestFileSystemOptionsHelper(Map<String, ?> env) {
         if (env == null) {
             this.env = createDefaultOptions();
@@ -31,26 +36,57 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
         }
     }
 
+    /**
+     * Returns the configured cache option.
+     *
+     * @return cache option, never {@code null}
+     */
     RestFileSystemOptions.CacheOptions getCacheOptions() {
         return getOption(RestFileSystemOptions.CACHE_OPTIONS, RestFileSystemOptions.CacheOptions.class, RestFileSystemOptions.CacheOptions.NONE);
     }
 
+    /**
+     * Determines whether SSL should be used when contacting the server.
+     *
+     * @return SSL option
+     */
     RestFileSystemOptions.SSLOptions isUseSSL() {
         return getOption(RestFileSystemOptions.USE_SSL, RestFileSystemOptions.SSLOptions.class, RestFileSystemOptions.SSLOptions.AUTO);
     }
 
+    /**
+     * Returns the cache fallback behaviour.
+     *
+     * @return cache fallback option
+     */
     RestFileSystemOptions.CacheFallback getCacheFallback() {
         return getOption(RestFileSystemOptions.CACHE_FALLBACK, RestFileSystemOptions.CacheFallback.class, RestFileSystemOptions.CacheFallback.OFFLINE);
     }
 
+    /**
+     * Indicates whether cache logging is enabled.
+     *
+     * @return {@code true} if cache logging is enabled
+     */
     boolean isCacheLogging() {
         return getOption(RestFileSystemOptions.CACHE_LOGGING, Boolean.class, Boolean.FALSE);
     }
 
+    /**
+     * Specifies whether alternate cache locations are permitted if the primary
+     * location is unavailable.
+     *
+     * @return {@code true} if alternate locations are allowed
+     */
     boolean allowAlternateCacheLoction() {
         return getOption(RestFileSystemOptions.ALLOW_ALTERNATE_CACHE_LOCATION, Boolean.class, Boolean.FALSE);
     }
 
+    /**
+     * Provides the location of the on-disk cache if configured.
+     *
+     * @return path to the disk cache or {@code null} if none
+     */
     Path getDiskCacheLocation() {
         Object result = env.get(RestFileSystemOptions.CACHE_LOCATION);
         if (result == null) {
@@ -65,7 +101,12 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
             throw new IllegalArgumentException("Invalid value for option " + RestFileSystemOptions.CACHE_LOCATION + ": " + result);
         }
     }
-    
+
+    /**
+     * Returns the mount point that should be considered the root of the server.
+     *
+     * @return mount point URI
+     */
     URI getMountPoint() {
         Object result = env.get(RestFileSystemOptions.MOUNT_POINT);
         if (result == null) {

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemProvider.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemProvider.java
@@ -37,9 +37,8 @@ import org.lsst.ccs.rest.file.server.client.VersionedFileAttributes;
 import org.lsst.ccs.utilities.misc.ExtendableURLStreamHandlerFactory;
 
 /**
- * Implementation of FileSystemProvider for a CCS rest file ser
- *
- * @author tonyj
+ * {@link FileSystemProvider} implementation that creates and manages
+ * {@link RestFileSystem} instances for communicating with the REST file server.
  */
 public class RestFileSystemProvider extends FileSystemProvider {
 
@@ -48,11 +47,17 @@ public class RestFileSystemProvider extends FileSystemProvider {
 
     private final Map<URI, RestFileSystem> cache = new ConcurrentHashMap<>();
 
+    /** {@inheritDoc} */
     @Override
     public String getScheme() {
         return "ccs";
     }
 
+    /**
+     * Sets default options to be used when creating new file systems.
+     *
+     * @param defaultEnv map of default environment values
+     */
     public static void setDefaultFileSystemOption(Map<String, ?> defaultEnv) {
         defaultEnvironment = defaultEnv;
     }
@@ -82,11 +87,13 @@ public class RestFileSystemProvider extends FileSystemProvider {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public FileSystem getFileSystem(URI uri) {
         return cache.get(uri);
     }
 
+    /** {@inheritDoc} */
     @Override
     public Path getPath(URI uri) {
         if (!getScheme().equals(uri.getScheme())) {
@@ -176,9 +183,10 @@ public class RestFileSystemProvider extends FileSystemProvider {
         return false;
     }
 
+    /** {@inheritDoc} */
     @Override
     public FileStore getFileStore(Path path) throws IOException {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
@@ -187,6 +195,7 @@ public class RestFileSystemProvider extends FileSystemProvider {
         restPath.getClient().checkAccess(restPath, modes);
     }
 
+    /** {@inheritDoc} */
     @Override
     public <V extends FileAttributeView> V getFileAttributeView(Path path, Class<V> type, LinkOption... options) {
         final RestPath restPath = toRestPath(path);

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestPath.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestPath.java
@@ -10,8 +10,8 @@ import java.util.List;
 import org.lsst.ccs.web.rest.file.server.data.RestFileInfo;
 
 /**
- *
- * @author tonyj
+ * Concrete {@link java.nio.file.Path} implementation used by
+ * {@link RestFileSystem}.
  */
 class RestPath extends AbstractPath {
 
@@ -59,11 +59,13 @@ class RestPath extends AbstractPath {
         return ((RestFileSystem) this.getFileSystem()).getClient();
     }
 
+    /** {@inheritDoc} */
     @Override
     public FileSystem getFileSystem() {
         return fileSystem;
     }
 
+    /** {@inheritDoc} */
     @Override
     public URI toUri() {
         return fileSystem.getURI(this.toAbsolutePath().toString().substring(1));

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestVersionedFileAttributes.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestVersionedFileAttributes.java
@@ -4,51 +4,60 @@ import java.nio.file.attribute.BasicFileAttributes;
 import org.lsst.ccs.rest.file.server.client.VersionedFileAttributes;
 import org.lsst.ccs.web.rest.file.server.data.VersionInfoV2;
 
-
 /**
- *
- * @author tonyj
+ * {@link VersionedFileAttributes} backed by {@link VersionInfoV2} metadata from
+ * the REST service.
  */
 class RestVersionedFileAttributes extends RestFileAttributes implements VersionedFileAttributes {
 
     private final VersionInfoV2 info;
 
+    /**
+     * Creates a new attribute view for a versioned file.
+     *
+     * @param info version information returned by the server
+     */
     RestVersionedFileAttributes(VersionInfoV2 info) {
-        super(info.getVersions().get(info.getDefault()-1));
+        super(info.getVersions().get(info.getDefault() - 1));
         this.info = info;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int[] getVersions() {
         return info.getVersions().stream().mapToInt(v -> v.getVersion()).toArray();
     }
 
+    /** {@inheritDoc} */
     @Override
     public int getLatestVersion() {
         return info.getLatest();
     }
 
+    /** {@inheritDoc} */
     @Override
     public int getDefaultVersion() {
         return info.getDefault();
     }
 
+    /** {@inheritDoc} */
     @Override
     public BasicFileAttributes getAttributes(int version) {
-        VersionInfoV2.Version versionAttributes = info.getVersions().get(version-1);
+        VersionInfoV2.Version versionAttributes = info.getVersions().get(version - 1);
         return new RestFileAttributes(versionAttributes);
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isHidden(int version) {
-        VersionInfoV2.Version versionAttributes = info.getVersions().get(version-1);
+        VersionInfoV2.Version versionAttributes = info.getVersions().get(version - 1);
         return versionAttributes.isHidden();
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getComment(int version) {
-        VersionInfoV2.Version versionAttributes = info.getVersions().get(version-1);
+        VersionInfoV2.Version versionAttributes = info.getVersions().get(version - 1);
         return versionAttributes.getComment();
     }
-    
 }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/package-info.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Internal classes that implement the REST file system. These classes are not
+ * intended for direct use by API consumers.
+ */
+package org.lsst.ccs.rest.file.server.client.implementation;

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/AbstractFileSystem.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/AbstractFileSystem.java
@@ -6,8 +6,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 
 /**
- *
- * @author tonyj
+ * Minimal {@link FileSystem} implementation providing Unix-like behaviour for
+ * use by the REST client.
  */
 public abstract class AbstractFileSystem extends FileSystem {
 
@@ -20,21 +20,25 @@ public abstract class AbstractFileSystem extends FileSystem {
         isOpen = false;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isOpen() {
         return isOpen;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean isReadOnly() {
         return isReadOnly;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getSeparator() {
         return "/";
     }
 
+    /** {@inheritDoc} */
     @Override
     public Iterable<Path> getRootDirectories() {
         return Collections.singletonList(root);

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/AbstractPath.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/AbstractPath.java
@@ -16,14 +16,12 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
- * An implementation of Path which should work for any unix-lije file system
+ * An implementation of {@link Path} that works for any Unix-like file system
  * with
  * <ul>
  * <li>A single root
  * <li>Unix like file semantics
  * </ul>
- *
- * @author tonyj
  */
 public abstract class AbstractPath implements Path {
 
@@ -33,6 +31,12 @@ public abstract class AbstractPath implements Path {
     private final LinkedList<String> path;
     private final AbstractPathBuilder builder;
 
+    /**
+     * Creates a path from a string representation.
+     *
+     * @param builder factory used to create additional path instances
+     * @param path textual path representation
+     */
     protected AbstractPath(AbstractPathBuilder builder, String path) {
         this.builder = builder;
         this.isAbsolute = path.startsWith(DELIMETER);
@@ -43,6 +47,13 @@ public abstract class AbstractPath implements Path {
         this.path = path.isEmpty() ? EMPTY_PATH : new LinkedList<>(Arrays.asList(path.split(DELIMETER + "+")));
     }
 
+    /**
+     * Creates a path from its components.
+     *
+     * @param builder factory used to create additional path instances
+     * @param isAbsolute whether the path is absolute
+     * @param path individual elements of the path
+     */
     protected AbstractPath(AbstractPathBuilder builder, boolean isAbsolute, List<String> path) {
         this.builder = builder;
         this.isAbsolute = isAbsolute;

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/AbstractPathBuilder.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/AbstractPathBuilder.java
@@ -4,11 +4,26 @@ import java.nio.file.Path;
 import java.util.List;
 
 /**
- *
- * @author tonyj
+ * Factory used by {@link AbstractPath} implementations to create new path
+ * instances.
  */
 public interface AbstractPathBuilder {
 
+    /**
+     * Builds a path from the supplied elements.
+     *
+     * @param first the first element of the path
+     * @param more additional elements
+     * @return constructed path
+     */
     Path getPath(String first, String... more);
+
+    /**
+     * Builds a path from a list of elements.
+     *
+     * @param absolute whether the path is absolute
+     * @param path elements that form the path
+     * @return constructed path
+     */
     Path getPath(boolean absolute, List<String> path);
 }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/package-info.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/unixlike/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Support classes providing a minimal Unix-like file system and path
+ * implementation used internally by the REST client.
+ */
+package org.lsst.ccs.rest.file.server.client.implementation.unixlike;

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/package-info.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Client APIs for interacting with the CCS REST file server.
+ */
+package org.lsst.ccs.rest.file.server.client;

--- a/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/Constants.java
+++ b/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/Constants.java
@@ -1,10 +1,14 @@
 package org.lsst.ccs.web.rest.file.server.data;
 
 /**
+ * Constants used by the REST file server API.
  *
  * @author tonyj
  */
 public class Constants {
+    /**
+     * HTTP header used to indicate the protocol version expected by the client.
+     */
     public static final String PROTOCOL_VERSION_HEADER = "x-protocol-version";
 
 }

--- a/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/IOExceptionResponse.java
+++ b/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/IOExceptionResponse.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * A response sent when a IOException is generated in the rest file server.
+ * Response payload returned when the REST file server encounters an
+ * {@link java.io.IOException}.
+ *
  * @author tonyj
  */
 public class IOExceptionResponse {
@@ -13,16 +15,32 @@ public class IOExceptionResponse {
     private final String exceptionClass;
     private final String message;
 
+    /**
+     * Creates a new response describing the encountered exception.
+     *
+     * @param exceptionClass fully qualified class name of the exception
+     * @param message error message from the exception
+     */
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public IOExceptionResponse(@JsonProperty("exceptionClass") String exceptionClass, @JsonProperty("message") String message) {
         this.exceptionClass = exceptionClass;
         this.message = message;
     }
 
+    /**
+     * Gets the fully qualified class name of the exception.
+     *
+     * @return exception class name
+     */
     public String getExceptionClass() {
         return exceptionClass;
     }
 
+    /**
+     * Gets the exception message.
+     *
+     * @return exception message
+     */
     public String getMessage() {
         return message;
     }

--- a/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/RestFileInfo.java
+++ b/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/RestFileInfo.java
@@ -14,7 +14,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Information returned by the rest file server for a directory or file
+ * Represents metadata about a file or directory returned by the REST file
+ * server.
  *
  * @author tonyj
  */
@@ -35,20 +36,37 @@ public class RestFileInfo implements Serializable {
     private final boolean isVersionedFile;
     private final List<RestFileInfo> children;
 
+    /**
+     * Creates a {@code RestFileInfo} from JSON properties.
+     *
+     * @param lastModified last modification time in milliseconds
+     * @param creationTime creation time in milliseconds
+     * @param lastAccessTime last access time in milliseconds
+     * @param size size of the file in bytes
+     * @param mimeType detected MIME type of the file
+     * @param name file name
+     * @param fileKey unique file key
+     * @param directory {@code true} if the path is a directory
+     * @param other {@code true} if the path is some other type
+     * @param regularFile {@code true} if the path is a regular file
+     * @param symbolicLink {@code true} if the path is a symbolic link
+     * @param versionedFile {@code true} if the path is a versioned file
+     * @param children child entries if the path is a directory
+     */
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public RestFileInfo(
-            @JsonProperty("lastModified") long lastModified, 
-            @JsonProperty("creationTime") long creationTime, 
-            @JsonProperty("lastAccessTime") long lastAccessTime, 
-            @JsonProperty("size") long size, 
-            @JsonProperty("mimeType") String mimeType, 
-            @JsonProperty("name") String name, 
-            @JsonProperty("fileKey") String fileKey, 
-            @JsonProperty("directory") boolean directory, 
-            @JsonProperty("other") boolean other, 
-            @JsonProperty("regularFile") boolean regularFile, 
-            @JsonProperty("symbolicLink") boolean symbolicLink, 
-            @JsonProperty("versionedFile") boolean versionedFile, 
+            @JsonProperty("lastModified") long lastModified,
+            @JsonProperty("creationTime") long creationTime,
+            @JsonProperty("lastAccessTime") long lastAccessTime,
+            @JsonProperty("size") long size,
+            @JsonProperty("mimeType") String mimeType,
+            @JsonProperty("name") String name,
+            @JsonProperty("fileKey") String fileKey,
+            @JsonProperty("directory") boolean directory,
+            @JsonProperty("other") boolean other,
+            @JsonProperty("regularFile") boolean regularFile,
+            @JsonProperty("symbolicLink") boolean symbolicLink,
+            @JsonProperty("versionedFile") boolean versionedFile,
             @JsonProperty("children") List<RestFileInfo> children) {
         this.lastModified = lastModified;
         this.creationTime = creationTime;
@@ -65,6 +83,11 @@ public class RestFileInfo implements Serializable {
         this.children = children;
     }
     
+    /**
+     * Copy constructor.
+     *
+     * @param other existing {@code RestFileInfo} to copy
+     */
     public RestFileInfo(RestFileInfo other) {
         this.lastModified = other.lastModified;
         this.creationTime = other.creationTime;
@@ -81,10 +104,28 @@ public class RestFileInfo implements Serializable {
         this.children = other.children;        
     }
     
+    /**
+     * Constructs a {@code RestFileInfo} for the supplied file.
+     *
+     * @param file file path
+     * @param fileAttributes file attributes
+     * @param isVersionedFile {@code true} if the file is versioned
+     * @throws IOException if the content type cannot be determined
+     */
     public RestFileInfo(Path file, BasicFileAttributes fileAttributes, boolean isVersionedFile) throws IOException {
         this(file, fileAttributes, isVersionedFile, null);
     }
-    
+
+    /**
+     * Constructs a {@code RestFileInfo} for the supplied file with child
+     * entries.
+     *
+     * @param file file path
+     * @param fileAttributes file attributes
+     * @param isVersionedFile {@code true} if the file is versioned
+     * @param children child file information
+     * @throws IOException if the content type cannot be determined
+     */
     public RestFileInfo(Path file, BasicFileAttributes fileAttributes, boolean isVersionedFile, List<RestFileInfo> children) throws IOException {
         this.name = file.getFileName().toString();
         this.size = fileAttributes.size();
@@ -101,63 +142,140 @@ public class RestFileInfo implements Serializable {
         this.children = children;
     }
 
+    /**
+     * Gets the last modification time.
+     *
+     * @return last modification time in milliseconds since the epoch
+     */
     public long getLastModified() {
         return lastModified;
     }
 
+    /**
+     * Gets the creation time.
+     *
+     * @return creation time in milliseconds since the epoch
+     */
     public long getCreationTime() {
         return creationTime;
     }
 
+    /**
+     * Gets the last access time.
+     *
+     * @return last access time in milliseconds since the epoch
+     */
     public long getLastAccessTime() {
         return lastAccessTime;
     }
 
+    /**
+     * Gets the size of the file.
+     *
+     * @return file size in bytes
+     */
     public long getSize() {
         return size;
     }
 
+    /**
+     * Gets the detected MIME type of the file.
+     *
+     * @return MIME type, or {@code null} if unknown
+     */
     public String getMimeType() {
         return mimeType;
     }
 
+    /**
+     * Gets the file name.
+     *
+     * @return file name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the unique file key.
+     *
+     * @return file key string
+     */
     public String getFileKey() {
         return fileKey;
     }
 
+    /**
+     * Determines whether the path represents a directory.
+     *
+     * @return {@code true} if this is a directory and not a versioned file
+     */
     public boolean isDirectory() {
         return isDirectory && !isVersionedFile;
     }
 
+    /**
+     * Determines whether the path represents an "other" file type.
+     *
+     * @return {@code true} if the path is some other type or a versioned file
+     */
     public boolean isOther() {
         return isOther || isVersionedFile;
     }
 
+    /**
+     * Determines whether the path represents a regular file.
+     *
+     * @return {@code true} if this is a regular file
+     */
     public boolean isRegularFile() {
         return isRegularFile;
     }
 
+    /**
+     * Determines whether the path represents a symbolic link.
+     *
+     * @return {@code true} if this is a symbolic link
+     */
     public boolean isSymbolicLink() {
         return isSymbolicLink;
     }
 
+    /**
+     * Determines whether the path represents a versioned file.
+     *
+     * @return {@code true} if this is a versioned file
+     */
     public boolean isVersionedFile() {
         return isVersionedFile;
     }
 
+    /**
+     * Gets the child entries of this file or directory.
+     *
+     * @return list of child file information, or {@code null} if none
+     */
     public List<RestFileInfo> getChildren() {
         return children;
     }
 
+    /**
+     * Returns a string representation of this file description for logging or
+     * debugging purposes.
+     *
+     * @return human readable representation
+     */
     @Override
     public String toString() {
         return "RestFileInfo{" + "lastModified=" + lastModified + ", size=" + size + ", mimeType=" + mimeType + ", name=" + name + '}';
     }
 
+    /**
+     * Converts this instance to a map of simple values suitable for
+     * serialization.
+     *
+     * @return map containing the file metadata
+     */
     public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
         result.put("lastAccessTime", FileTime.fromMillis(lastAccessTime));

--- a/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/VersionInfo.java
+++ b/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/VersionInfo.java
@@ -12,7 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Information returned by the rest-file-server for a versioned file
+ * Represents version information for a versioned file as returned by the REST
+ * file server.
  *
  * @author tonyj
  */
@@ -22,6 +23,13 @@ public class VersionInfo implements Serializable {
     private final int latestVersion;
     private final List<VersionInfo.Version> versions;
 
+    /**
+     * Creates a new {@code VersionInfo} from JSON properties.
+     *
+     * @param defaultVersion default version number
+     * @param latestVersion latest version number
+     * @param versions list of available versions
+     */
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public VersionInfo(@JsonProperty("default") int defaultVersion, @JsonProperty("latest") int latestVersion, @JsonProperty("versions")  List<VersionInfo.Version> versions) {
         this.defaultVersion = defaultVersion;
@@ -39,67 +47,137 @@ public class VersionInfo implements Serializable {
         this.versions = oldVersions;
     }
 
+    /**
+     * Gets the default version number.
+     *
+     * @return default version
+     */
     public int getDefault() {
         return defaultVersion;
     }
 
+    /**
+     * Gets the latest version number.
+     *
+     * @return latest version
+     */
     public int getLatest() {
         return latestVersion;
     }
 
+    /**
+     * Gets the list of available versions.
+     *
+     * @return list of version metadata
+     */
     public List<Version> getVersions() {
         return versions;
     }
 
+    /**
+     * Metadata for a specific version of a file.
+     */
     public static class Version extends RestFileInfo {
 
         private final int version;
 
+        /**
+         * Creates a {@code Version} from JSON properties.
+         *
+         * @param lastModified last modification time in milliseconds
+         * @param creationTime creation time in milliseconds
+         * @param lastAccessTime last access time in milliseconds
+         * @param size size of the file in bytes
+         * @param mimeType detected MIME type
+         * @param name file name
+         * @param fileKey unique file key
+         * @param directory {@code true} if the path is a directory
+         * @param other {@code true} if the path is some other type
+         * @param regularFile {@code true} if the path is a regular file
+         * @param symbolicLink {@code true} if the path is a symbolic link
+         * @param versionedFile {@code true} if the path is a versioned file
+         * @param children child entries if the path is a directory
+         * @param version version number
+         */
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         public Version(
-            @JsonProperty("lastModified") long lastModified, 
-            @JsonProperty("creationTime") long creationTime, 
-            @JsonProperty("lastAccessTime") long lastAccessTime, 
-            @JsonProperty("size") long size, 
-            @JsonProperty("mimeType") String mimeType, 
-            @JsonProperty("name") String name, 
-            @JsonProperty("fileKey") String fileKey, 
-            @JsonProperty("directory") boolean directory, 
-            @JsonProperty("other") boolean other, 
-            @JsonProperty("regularFile") boolean regularFile, 
-            @JsonProperty("symbolicLink") boolean symbolicLink, 
-            @JsonProperty("versionedFile") boolean versionedFile, 
+            @JsonProperty("lastModified") long lastModified,
+            @JsonProperty("creationTime") long creationTime,
+            @JsonProperty("lastAccessTime") long lastAccessTime,
+            @JsonProperty("size") long size,
+            @JsonProperty("mimeType") String mimeType,
+            @JsonProperty("name") String name,
+            @JsonProperty("fileKey") String fileKey,
+            @JsonProperty("directory") boolean directory,
+            @JsonProperty("other") boolean other,
+            @JsonProperty("regularFile") boolean regularFile,
+            @JsonProperty("symbolicLink") boolean symbolicLink,
+            @JsonProperty("versionedFile") boolean versionedFile,
             @JsonProperty("children") List<RestFileInfo> children,
             @JsonProperty("version") int version) {
             super(lastModified, creationTime, lastAccessTime, size, mimeType, name, fileKey, directory, other, regularFile, symbolicLink, versionedFile, children);
             this.version = version;
         }
-        
+
+        /**
+         * Creates a {@code Version} from a file.
+         *
+         * @param file file path
+         * @param fileAttributes file attributes
+         * @param version version number
+         * @throws IOException if the content type cannot be determined
+         */
         public Version(Path file, BasicFileAttributes fileAttributes, int version) throws IOException {
             super(file, fileAttributes, false);
             this.version = version;
         }
 
+        /**
+         * Copy constructor.
+         *
+         * @param other version to copy
+         */
         public Version(Version other) {
             super(other);
             this.version = other.version;
         }
-        
+
+        /**
+         * Creates a {@code Version} from a v2 representation.
+         *
+         * @param v2 v2 version information
+         */
         public Version(VersionInfoV2.Version v2) {
             super(v2);
             this.version = v2.getVersion();
         }
 
+        /**
+         * Gets the version number.
+         *
+         * @return version number
+         */
         public int getVersion() {
             return version;
         }
     }
 
+    /**
+     * Returns a debug representation of this version information.
+     *
+     * @return human readable representation
+     */
     @Override
     public String toString() {
         return "VersionInfo{" + "defaultVersion=" + defaultVersion + ", latestVersion=" + latestVersion + ", versions=" + versions + '}';
     }
 
+    /**
+     * Converts the core fields of this instance into a map for convenient
+     * serialization.
+     *
+     * @return map containing the latest and default version numbers
+     */
     public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
         result.put("latestVersion", getLatest());

--- a/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/VersionInfoV2.java
+++ b/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/VersionInfoV2.java
@@ -12,7 +12,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Information returned by the rest-file-server for a versioned file
+ * Represents version information for a file as returned by the REST file
+ * server.
+ *
  * @author tonyj
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -22,25 +24,53 @@ public class VersionInfoV2 implements Serializable {
     private final int latestVersion;
     private final List<VersionInfoV2.Version> versions;
 
+    /**
+     * Creates a new {@code VersionInfoV2} from JSON properties.
+     *
+     * @param defaultVersion default version number
+     * @param latestVersion latest version number
+     * @param versions list of available versions
+     */
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public VersionInfoV2(@JsonProperty("default") int defaultVersion, @JsonProperty("latest") int latestVersion, @JsonProperty("versions") List<Version> versions) {
         this.defaultVersion = defaultVersion;
         this.latestVersion = latestVersion;
         this.versions = versions;
     }
-    
+
+    /**
+     * Gets the default version number.
+     *
+     * @return default version
+     */
     public int getDefault() {
         return defaultVersion;
     }
 
+    /**
+     * Gets the latest version number.
+     *
+     * @return latest version
+     */
     public int getLatest() {
         return latestVersion;
     }
 
+    /**
+     * Gets the list of available versions.
+     *
+     * @return list of version metadata
+     */
     public List<Version> getVersions() {
         return versions;
     }
 
+    /**
+     * Downgrades this object to an older protocol version if necessary.
+     *
+     * @param protocolVersion requested protocol version
+     * @return a compatible representation for the requested protocol version
+     */
     public Serializable downgrade(Integer protocolVersion) {
         if (protocolVersion == null || protocolVersion<2) {
             return new VersionInfo(this);
@@ -54,23 +84,43 @@ public class VersionInfoV2 implements Serializable {
         private final int version;
         private final boolean hidden;
         private final String comment;
-                
+
+        /**
+         * Creates a {@code Version} from JSON properties.
+         *
+         * @param lastModified last modification time in milliseconds
+         * @param creationTime creation time in milliseconds
+         * @param lastAccessTime last access time in milliseconds
+         * @param size size of the file in bytes
+         * @param mimeType detected MIME type
+         * @param name file name
+         * @param fileKey unique file key
+         * @param directory {@code true} if the path is a directory
+         * @param other {@code true} if the path is some other type
+         * @param regularFile {@code true} if the path is a regular file
+         * @param symbolicLink {@code true} if the path is a symbolic link
+         * @param versionedFile {@code true} if the path is a versioned file
+         * @param children child entries if the path is a directory
+         * @param version version number
+         * @param hidden {@code true} if the version is hidden
+         * @param comment version comment
+         */
         @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
         public Version(
-            @JsonProperty("lastModified") long lastModified, 
-            @JsonProperty("creationTime") long creationTime, 
-            @JsonProperty("lastAccessTime") long lastAccessTime, 
-            @JsonProperty("size") long size, 
-            @JsonProperty("mimeType") String mimeType, 
-            @JsonProperty("name") String name, 
-            @JsonProperty("fileKey") String fileKey, 
-            @JsonProperty("directory") boolean directory, 
-            @JsonProperty("other") boolean other, 
-            @JsonProperty("regularFile") boolean regularFile, 
-            @JsonProperty("symbolicLink") boolean symbolicLink, 
-            @JsonProperty("versionedFile") boolean versionedFile, 
+            @JsonProperty("lastModified") long lastModified,
+            @JsonProperty("creationTime") long creationTime,
+            @JsonProperty("lastAccessTime") long lastAccessTime,
+            @JsonProperty("size") long size,
+            @JsonProperty("mimeType") String mimeType,
+            @JsonProperty("name") String name,
+            @JsonProperty("fileKey") String fileKey,
+            @JsonProperty("directory") boolean directory,
+            @JsonProperty("other") boolean other,
+            @JsonProperty("regularFile") boolean regularFile,
+            @JsonProperty("symbolicLink") boolean symbolicLink,
+            @JsonProperty("versionedFile") boolean versionedFile,
             @JsonProperty("children") List<RestFileInfo> children,
-            @JsonProperty("version") int version, 
+            @JsonProperty("version") int version,
             @JsonProperty("hidden") boolean hidden,
             @JsonProperty("comment") String comment) {
 
@@ -79,7 +129,17 @@ public class VersionInfoV2 implements Serializable {
             this.hidden = hidden;
             this.comment = comment == null ? "" : comment;
         }
-        
+
+        /**
+         * Creates a {@code Version} for the specified file.
+         *
+         * @param file file path
+         * @param fileAttributes file attributes
+         * @param version version number
+         * @param hidden {@code true} if the version is hidden
+         * @param comment version comment
+         * @throws IOException if the content type cannot be determined
+         */
         public Version(Path file, BasicFileAttributes fileAttributes, int version, boolean hidden, String comment) throws IOException {
             super(file, fileAttributes, false);
             this.version = version;
@@ -87,25 +147,49 @@ public class VersionInfoV2 implements Serializable {
             this.comment = comment;
         }
 
+        /**
+         * Gets the version number.
+         *
+         * @return version number
+         */
         public int getVersion() {
             return version;
         }
 
+        /**
+         * Indicates whether this version is hidden.
+         *
+         * @return {@code true} if the version is hidden
+         */
         public boolean isHidden() {
             return hidden;
         }
 
+        /**
+         * Gets the comment associated with this version.
+         *
+         * @return version comment
+         */
         public String getComment() {
             return comment;
         }
     }
 
+    /**
+     * Returns a debug representation of this version metadata object.
+     *
+     * @return human readable representation
+     */
     @Override
     public String toString() {
         return "VersionInfo{" + "defaultVersion=" + defaultVersion + ", latestVersion=" + latestVersion + ", versions=" + versions + '}';
     }
-    
 
+    /**
+     * Converts this instance into a map for convenient serialization.
+     *
+     * @return map containing the latest and default version numbers
+     */
     public Map<String, Object> toMap() {
         Map<String, Object> result = new HashMap<>();
         result.put("latestVersion", getLatest());

--- a/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/VersionOptions.java
+++ b/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/VersionOptions.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
+ * Options used when creating or updating a versioned file via the REST file
+ * server.
  *
  * @author tonyj
  */
@@ -14,6 +16,14 @@ public class VersionOptions {
     private final String comment;
     private final Boolean makeDefault;
 
+    /**
+     * Creates a new {@code VersionOptions} instance from JSON properties.
+     *
+     * @param version version number the options apply to
+     * @param hidden whether the version should be hidden
+     * @param comment comment associated with the version
+     * @param makeDefault whether the version should be made the default
+     */
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public VersionOptions(@JsonProperty(value = "version") int version, @JsonProperty(value = "hidden") Boolean hidden, @JsonProperty(value = "comment") String comment, @JsonProperty(value = "default") Boolean makeDefault) {
         this.version = version;
@@ -22,22 +32,45 @@ public class VersionOptions {
         this.makeDefault = makeDefault;
     }
 
+    /**
+     * Gets the version number this options object applies to.
+     *
+     * @return version number
+     */
     public int getVersion() {
         return version;
     }
 
+    /**
+     * Indicates whether the version should be hidden.
+     *
+     * @return {@code Boolean.TRUE} if the version should be hidden, otherwise {@code Boolean.FALSE} or {@code null}
+     */
     public Boolean getHidden() {
         return hidden;
     }
 
+    /**
+     * Gets the comment associated with the version.
+     *
+     * @return version comment
+     */
     public String getComment() {
         return comment;
     }
 
+    /**
+     * Indicates whether the version should become the default.
+     *
+     * @return {@code Boolean.TRUE} if the version should be the default, otherwise {@code Boolean.FALSE} or {@code null}
+     */
     public Boolean getMakeDefault() {
         return makeDefault;
     }
 
+    /**
+     * Builder for {@link VersionOptions} instances.
+     */
     public static class Builder {
 
         private final int version;
@@ -45,25 +78,52 @@ public class VersionOptions {
         private boolean hidden;
         private boolean defaultVersion;
 
+        /**
+         * Creates a new builder for the specified version.
+         *
+         * @param version version number
+         */
         public Builder(int version) {
             this.version = version;
         }
-        
+
+        /**
+         * Sets the comment for the version.
+         *
+         * @param comment comment text
+         * @return this builder for chaining
+         */
         public Builder setComment(String comment) {
             this.comment = comment;
             return this;
         }
-        
+
+        /**
+         * Marks the version as hidden.
+         *
+         * @param hidden {@code true} to hide the version
+         * @return this builder for chaining
+         */
         public Builder setHidden(boolean hidden) {
             this.hidden = hidden;
             return this;
         }
-        
+
+        /**
+         * Marks the version as the default.
+         *
+         * @return this builder for chaining
+         */
         public Builder setDefault() {
             this.defaultVersion = true;
             return this;
         }
-        
+
+        /**
+         * Builds a {@link VersionOptions} instance.
+         *
+         * @return configured {@code VersionOptions}
+         */
         public VersionOptions build() {
             return new VersionOptions(version, hidden, comment, defaultVersion);
         }

--- a/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/package-info.java
+++ b/common/src/main/java/org/lsst/ccs/web/rest/file/server/data/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Data transfer objects and constants for the REST file server.
+ *
+ * <p>This package contains simple value classes that describe files, versions
+ * and related options exchanged with the REST file server.</p>
+ */
+package org.lsst.ccs.web.rest.file.server.data;

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/CORSResponseFilter.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/CORSResponseFilter.java
@@ -7,9 +7,20 @@ import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
 
+/**
+ * {@link ContainerResponseFilter} that adds standard Cross-Origin Resource
+ * Sharing (CORS) headers to every HTTP response.
+ */
 @Provider
 public class CORSResponseFilter implements ContainerResponseFilter {
 
+    /**
+     * Adds permissive CORS headers to the given response.
+     *
+     * @param requestContext the incoming request
+     * @param responseContext the outgoing response to augment
+     * @throws IOException if an I/O error occurs while filtering
+     */
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
             throws IOException {

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/ETagHelper.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/ETagHelper.java
@@ -9,6 +9,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 /**
+ * Utility methods for computing and formatting entity tags (ETags) used in
+ * HTTP caching.
  *
  * @author tonyj
  */
@@ -16,6 +18,12 @@ class ETagHelper {
 
     private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
 
+    /**
+     * Computes an MD5 based ETag for the supplied serializable object.
+     *
+     * @param object the object for which the tag should be generated
+     * @return a hex encoded representation of the object's digest
+     */
     public static String computeEtag(Serializable object) {
 
         try {
@@ -35,6 +43,12 @@ class ETagHelper {
         }
     }
 
+    /**
+     * Converts the supplied byte array to a hexadecimal string.
+     *
+     * @param bytes the bytes to convert
+     * @return the hexadecimal representation
+     */
     public static String bytesToHex(byte[] bytes) {
         byte[] hexChars = new byte[bytes.length * 2];
         for (int j = 0; j < bytes.length; j++) {

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/IOExceptionMapper.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/IOExceptionMapper.java
@@ -7,17 +7,27 @@ import javax.ws.rs.ext.ExceptionMapper;
 import org.lsst.ccs.web.rest.file.server.data.IOExceptionResponse;
 
 /**
- * Maps an IOException thrown in the server to a IOExceptionResponse
+ * Maps an {@link IOException} thrown by the server to a serialized
+ * {@link IOExceptionResponse} so the client receives structured error
+ * information.
+ *
  * @author tonyj
  */
 class IOExceptionMapper implements ExceptionMapper<IOException> {
 
+    /**
+     * Converts the supplied {@link IOException} into an HTTP response with a
+     * JSON body describing the error.
+     *
+     * @param e the exception to map
+     * @return a response containing an {@link IOExceptionResponse}
+     */
     @Override
     public Response toResponse(IOException e) {
         return Response
                 .status(IOExceptionResponse.RESPONSE_CODE)
                 .type(MediaType.APPLICATION_JSON)
-                .entity(new IOExceptionResponse(e.getClass().getCanonicalName(),e.getMessage()))
+                .entity(new IOExceptionResponse(e.getClass().getCanonicalName(), e.getMessage()))
                 .build();
     }
     

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/MyConfiguration.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/MyConfiguration.java
@@ -10,16 +10,30 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.lsst.ccs.web.rest.file.server.jwt.JWTTokenNeededFilter;
 
 /**
+ * Jersey {@link ResourceConfig} for the REST file server. The configuration
+ * registers all resource classes and optionally enables JWT based
+ * authentication.
  *
  * @author tonyj
  */
 @ApplicationPath("rest")
 public final class MyConfiguration extends ResourceConfig {
 
+    /**
+     * Creates a configuration that includes authentication.
+     *
+     * @throws IOException if Firebase credentials cannot be obtained
+     */
     public MyConfiguration() throws IOException {
         this(false);
     }
 
+    /**
+     * Creates a configuration optionally skipping authentication setup.
+     *
+     * @param skipAuthentication {@code true} to omit JWT authentication filters
+     * @throws IOException if Firebase credentials cannot be obtained
+     */
     public MyConfiguration(boolean skipAuthentication) throws IOException {
 
         if (!skipAuthentication) {

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/jwt/JWTTokenNeeded.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/jwt/JWTTokenNeeded.java
@@ -7,7 +7,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Target;
 
 /**
- * Interface to be used to makr rest methods which require authentication 
+ * Name-binding annotation used to mark JAX-RS resource classes or methods
+ * that require JWT-based authentication.
+ *
  * @author tonyj
  */
 @javax.ws.rs.NameBinding

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/jwt/JWTTokenNeededFilter.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/jwt/JWTTokenNeededFilter.java
@@ -18,6 +18,10 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 /**
+ * {@link ContainerRequestFilter} that enforces JWT authentication for
+ * resources annotated with {@link JWTTokenNeeded}. The filter optionally
+ * restricts access to a set of allowed IP addresses supplied via the
+ * {@code CCS_REST_ALLOWED_IPS} environment variable.
  *
  * @author tonyj
  */
@@ -32,6 +36,14 @@ public class JWTTokenNeededFilter implements ContainerRequestFilter {
     private static final String allowedIPs = System.getenv("CCS_REST_ALLOWED_IPS");
     private static final Pattern ALLOWED_IPS_PATTERN = allowedIPs == null ? null : Pattern.compile(allowedIPs);
 
+    /**
+     * Validates the JWT token and optional client IP address present in the
+     * current request. If validation fails the request is aborted with
+     * {@link Response.Status#UNAUTHORIZED}.
+     *
+     * @param requestContext context for the incoming request
+     * @throws IOException if an error occurs during verification
+     */
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/jwt/package-info.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/jwt/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Filters and annotations for JWT-based request authentication.
+ */
+package org.lsst.ccs.web.rest.file.server.jwt;

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/package-info.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resources and utilities that implement the file server.
+ */
+package org.lsst.ccs.web.rest.file.server;

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/standalone/Main.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/standalone/Main.java
@@ -12,6 +12,9 @@ import org.glassfish.jersey.jdkhttp.JdkHttpServerFactory;
 import org.lsst.ccs.web.rest.file.server.MyConfiguration;
 
 /**
+ * Standalone launcher for the REST file server using the JDK HTTP server.
+ * It bootstraps {@link MyConfiguration} and exposes the application on a
+ * local port for development or testing purposes.
  *
  * @author tonyj
  */
@@ -20,11 +23,25 @@ public class Main {
     private final URI serverURI;
     private final HttpServer httpServer;
 
+    /**
+     * Starts the server from the command line.
+     *
+     * @param args command line arguments (ignored)
+     * @throws IOException if the server cannot be started
+     * @throws URISyntaxException if the server URI is invalid
+     */
     public static void main(String[] args) throws IOException, URISyntaxException {
         Main main = new Main();
         main.run();
     }
 
+    /**
+     * Creates a new instance configured to serve files from a temporary
+     * directory on a fixed local port.
+     *
+     * @throws IOException if the file system cannot be prepared
+     * @throws URISyntaxException if the base URI is invalid
+     */
     Main() throws IOException, URISyntaxException {
         Path root = Paths.get("configFiles");
         Files.createDirectory(root);
@@ -40,6 +57,9 @@ public class Main {
         httpServer = JdkHttpServerFactory.createHttpServer(serverURI.resolve("rest"), rc, false);
     }
 
+    /**
+     * Starts the underlying HTTP server.
+     */
     private void run() {
         httpServer.start();
         System.out.println("Config file server running at " + serverURI);

--- a/war/src/main/java/org/lsst/ccs/web/rest/file/server/standalone/package-info.java
+++ b/war/src/main/java/org/lsst/ccs/web/rest/file/server/standalone/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Standalone helper for running the REST file server using the JDK HTTP server.
+ */
+package org.lsst.ccs.web.rest.file.server.standalone;


### PR DESCRIPTION
## Summary
- document REST file metadata structure with detailed class and method Javadocs
- clarify version metadata classes and builder usage
- add API constant documentation and error response details
- add package-level overview and document map conversions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for org.lsst:org-lsst-ccs-rest-file-server:1.1.8-SNAPSHOT: The following artifacts could not be resolved: org.lsst:org-lsst-ccs-parent:pom:3.1.5 (absent))*

------
https://chatgpt.com/codex/tasks/task_e_68acedc439408328a64ff839a00d1f75