### PR TITLE
LSSTCCS-3029 One shared cache per JVM (ADR 0003), option cascade (0002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ NIO provider), and `cli` (the `cfs` command-line tool).
 Documentation is organized by lifecycle under [`docs/`](docs/):
 
 - **Decisions (ADRs — the *why*)**
-  - [0001 — Per-file-system cache isolation](docs/decisions/0001-per-file-system-cache-isolation.md)
+  - [0001 — Per-file-system cache isolation](docs/decisions/0001-per-file-system-cache-isolation.md) (largely superseded by 0003)
   - [0002 — Option resolution cascade for the ccs:// client](docs/decisions/0002-option-resolution-cascade.md)
+  - [0003 — One shared cache per JVM, policy in the file system](docs/decisions/0003-shared-per-jvm-cache.md)
 - **Guides (the *how it behaves*)**
   - [Toolkit remote-file-server cache compatibility](docs/guides/toolkit-cache-compatibility.md)
 - **Workplans (the *how we'll build it*)**

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# CCS REST File Server
+
+A REST file server for the LSST Camera Control System (CCS). It exposes a directory tree on
+the server's filesystem over HTTP, with first-class support for **versioned files** (files
+that retain every prior version). Its headline feature is a client that implements the Java
+NIO `FileSystemProvider` SPI under the `ccs://` URI scheme, so remote files can be read and
+written through standard `java.nio.file.Files`/`Path` APIs as if they were local.
+
+The build has four modules: `common` (wire POJOs), `war` (the JAX-RS server), `client` (the
+NIO provider), and `cli` (the `cfs` command-line tool).
+
+## Using it
+
+- **Client (`ccs://` NIO provider)** — mount a server with `FileSystems.newFileSystem(URI, env)`
+  and use ordinary `Files`/`Path` calls. Options (caching, cache location, SSL, auth token,
+  mount point) are passed in the `env` map, via `RestFileSystemOptions.builder()`, or through
+  the `org.lsst.ccs.rest.file.client.defaultEnvironment` system property.
+- **CLI (`cfs`)** — `cat`, `edit`, `list`, `diff`, `move`, `mkdir`, `set`; defaults to the dev
+  server, override with `-r`.
+- **Toolkit cache behavior** — how the toolkit's configuration/persistence/dictionary remote
+  file servers cache, and how the client system property interacts with them:
+  [docs/guides/toolkit-cache-compatibility.md](docs/guides/toolkit-cache-compatibility.md).
+
+## Working on it
+
+Documentation is organized by lifecycle under [`docs/`](docs/):
+
+- **Decisions (ADRs — the *why*)**
+  - [0001 — Per-file-system cache isolation](docs/decisions/0001-per-file-system-cache-isolation.md)
+  - [0002 — Option resolution cascade for the ccs:// client](docs/decisions/0002-option-resolution-cascade.md)
+- **Guides (the *how it behaves*)**
+  - [Toolkit remote-file-server cache compatibility](docs/guides/toolkit-cache-compatibility.md)
+- **Workplans (the *how we'll build it*)**
+  - [LSSTCCS-3029 — Per-file-system cache isolation](docs/workplans/LSSTCCS-3029-per-file-system-cache-isolation.md)
+  - [HANDOFF — current state + backlog](docs/workplans/HANDOFF.md)
+
+## Build & test
+
+Multi-module Maven build (no wrapper; use a system `mvn`). Java 21.
+
+```
+mvn install                              # build all modules
+mvn -pl war,client -am install           # a module and its dependencies (client tests need the war test-jar)
+mvn -Dtest=CachingTest test -pl client   # a single test class
+```

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ Documentation is organized by lifecycle under [`docs/`](docs/):
 
 - **Decisions (ADRs — the *why*)**
   - [0001 — Per-file-system cache isolation](docs/decisions/0001-per-file-system-cache-isolation.md) (largely superseded by 0003)
-  - [0002 — Option resolution cascade for the ccs:// client](docs/decisions/0002-option-resolution-cascade.md)
-  - [0003 — One shared cache per JVM, policy in the file system](docs/decisions/0003-shared-per-jvm-cache.md)
+  - [0002 — Option resolution cascade for the ccs:// client](docs/decisions/0002-option-resolution-cascade.md) (amended by 0003)
+  - [0003 — One shared cache per JVM, global cache config, policy in the file system](docs/decisions/0003-shared-per-jvm-cache.md)
 - **Guides (the *how it behaves*)**
   - [Toolkit remote-file-server cache compatibility](docs/guides/toolkit-cache-compatibility.md)
 - **Workplans (the *how we'll build it*)**
-  - [LSSTCCS-3029 — Per-file-system cache isolation](docs/workplans/LSSTCCS-3029-per-file-system-cache-isolation.md)
+  - [LSSTCCS-3029 — One shared cache per JVM](docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md) (active — ADR 0003)
+  - [LSSTCCS-3029 — Per-file-system cache isolation](docs/workplans/LSSTCCS-3029-per-file-system-cache-isolation.md) (superseded — ADR 0001)
   - [HANDOFF — current state + backlog](docs/workplans/HANDOFF.md)
 
 ## Build & test

--- a/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/TopLevelCommand.java
+++ b/cli/src/main/java/org/lsst/ccs/rest/file/server/cli/TopLevelCommand.java
@@ -80,7 +80,9 @@ public class TopLevelCommand {
             options.put(RestFileSystemOptions.CACHE_FALLBACK, cacheFallback);
         }
         if (cacheLocation != null) {
-            options.put(RestFileSystemOptions.CACHE_LOCATION, cacheLocation);
+            // Cache location is JVM-global and fixed before the first mount (ADR 0003);
+            // set it here rather than as a per-file-system option, which is ignored.
+            RestFileSystemOptions.setCacheLocation(cacheLocation.toPath());
         }
         if (authToken != null) {
             options.put(RestFileSystemOptions.AUTH_TOKEN, authToken);

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/RestFileSystemOptions.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/RestFileSystemOptions.java
@@ -1,6 +1,5 @@
 package org.lsst.ccs.rest.file.server.client;
 
-import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -87,28 +86,6 @@ public class RestFileSystemOptions {
         private final Map<String, Object> map = new HashMap<>();
 
         /**
-         * Specifies the cache location using a {@link File} path.
-         *
-         * @param location directory where the cache should be stored
-         * @return this builder for method chaining
-         */
-        public Builder cacheLocation(File location) {
-            map.put(CACHE_LOCATION, location);
-            return this;
-        }
-
-        /**
-         * Specifies the cache location using a {@link Path}.
-         *
-         * @param location path where the cache should be stored
-         * @return this builder for method chaining
-         */
-        public Builder cacheLocation(Path location) {
-            map.put(CACHE_LOCATION, location);
-            return this;
-        }
-
-        /**
          * Enables or disables cache activity logging.
          *
          * @param log {@code true} to enable logging
@@ -164,17 +141,6 @@ public class RestFileSystemOptions {
         }
 
         /**
-         * Allows the cache to fall back to an alternate location when locked.
-         *
-         * @param allow {@code true} to permit alternate cache locations
-         * @return this builder for method chaining
-         */
-        public Builder ignoreLockedCache(boolean allow) {
-            map.put(ALLOW_ALTERNATE_CACHE_LOCATION, allow);
-            return this;
-        }
-
-        /**
          * Sets the mount point URI for the file system.
          *
          * @param mountPoint URI identifying the desired mount point
@@ -203,5 +169,20 @@ public class RestFileSystemOptions {
      */
     public static void setDefaultFileSystemEnvironment(Map<String, ?> defaultEnv) {
         RestFileSystemProvider.setDefaultFileSystemOption(defaultEnv);
+    }
+
+    /**
+     * Sets the JVM-global on-disk cache location. The cache is one-per-JVM (see
+     * ADR 0003) and its location is fixed once the first {@code ccs://} file
+     * system is created, so this must be called <em>before</em> any caching file
+     * system is opened; a location supplied later cannot take effect and is
+     * rejected. Takes precedence over the {@link #DEFAULT_ENV_PROPERTY} value;
+     * the spill flag still comes from that property.
+     *
+     * @param location directory where the disk cache should be stored
+     * @throws IllegalStateException if the cache location is already configured
+     */
+    public static void setCacheLocation(Path location) {
+        RestFileSystemProvider.setCacheLocation(location);
     }
 }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
@@ -10,12 +10,9 @@ import java.net.URI;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -32,32 +29,26 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
  * Simple in-memory or disk-backed cache used to store server responses. The
  * cache is optional and its behaviour is controlled by
  * {@link RestFileSystemOptions}.
+ * <p>
+ * There is one cache per JVM (see ADR 0003): a single JCS {@code default}
+ * region and, for {@code MEMORY_AND_DISK}, a single disk store at the resolved
+ * global cache location, shared by every mount. {@code Cache} is policy-free
+ * storage; the freshness/expiry policy lives in the per-mount
+ * {@link CacheRequestFilter}.
  */
 class Cache implements Closeable {
 
     private CacheAccess<URI, CacheEntry> map;
     private FileLock lock;
-    private RestFileSystemOptions.CacheFallback cacheFallback;
-    private final String region;
     private Path diskCacheLocation;
 
     /**
      * Creates a new cache instance based on the supplied options.
-     * <p>
-     * Each remote file system gets its own JCS region and (for
-     * {@code MEMORY_AND_DISK}) its own disk directory, both derived from a
-     * stable key computed from {@code serverURI}. This keeps the caches of
-     * multiple file systems in the same JVM fully isolated, so they neither
-     * share a region nor collide on the disk lock.
      *
      * @param options user supplied configuration
-     * @param serverURI the resolved full URI of the server (server root plus
-     *                   mount point) used to derive the per-server cache key
      * @throws IOException if the cache cannot be initialised
      */
-    Cache(RestFileSystemOptionsHelper options, URI serverURI) throws IOException {
-
-        this.region = regionKey(serverURI);
+    Cache(RestFileSystemOptionsHelper options) throws IOException {
 
         JCS.setLogSystem(LogManager.LOGSYSTEM_JAVA_UTIL_LOGGING);
 
@@ -71,106 +62,71 @@ class Cache implements Closeable {
             props.load(in);
         }
         if (options.getCacheOptions() == RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK) {
-            String aux = "DC_" + region;
-            Properties diskProps = new Properties();
             try ( InputStream in = Cache.class.getResourceAsStream("disk.ccf")) {
-                diskProps.load(in);
+                props.load(in);
             }
-            // Substitute the per-server region and auxiliary names into the disk template.
-            for (String name : diskProps.stringPropertyNames()) {
-                String key = name.replace("%REGION%", region).replace("%AUX%", aux);
-                String value = diskProps.getProperty(name).replace("%REGION%", region).replace("%AUX%", aux);
-                props.setProperty(key, value);
-            }
-            Path baseLocation = options.getDiskCacheLocation();
-            if (baseLocation != null) {
-                // Each server caches under its own subdirectory of the configured base
-                // location, so distinct servers never contend for the same disk lock.
-                Path cacheLocation = baseLocation.resolve(region);
-                // Check that we can lock the cache, and if not what to do about it
-                for (int n = 1; n < 100; n++) {
-                    Files.createDirectories(cacheLocation);
-                    if (Files.isDirectory(cacheLocation) || Files.isWritable(cacheLocation)) {
-                        Path lockFile = cacheLocation.resolve("lockFile");
-                        FileChannel lockFileChannel = FileChannel.open(lockFile, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-                        try {
-                            lock = lockFileChannel.tryLock();
-                            if (lock != null) {
-                                break;
-                            } else if (!options.allowAlternateCacheLoction()) {
-                                throw new IOException("Cache already in use");
-                            }
-                        } catch (OverlappingFileLockException x) {
-                            if (!options.allowAlternateCacheLoction()) {
-                                throw new IOException("Cache already in use", x);
-                            }
-                        }
-                        cacheLocation = cacheLocation.resolveSibling(cacheLocation.getFileName() + "-" + n);
-
-                    } else {
-                        throw new IOException("Invalid cache location: " + cacheLocation);
-                    }
-                }
-                if (lock == null) {
-                    throw new IOException("Cache already in use and unable to get alternate cache location");
-                }
-
-                this.diskCacheLocation = cacheLocation;
-                props.setProperty("jcs.auxiliary." + aux + ".attributes.DiskPath", cacheLocation.toAbsolutePath().toString());
-            }
+            Path cacheLocation = lockCacheLocation();
+            this.diskCacheLocation = cacheLocation;
+            props.setProperty("jcs.auxiliary.DC.attributes.DiskPath", cacheLocation.toAbsolutePath().toString());
         }
         CompositeCacheManager ccm = CompositeCacheManager.getUnconfiguredInstance();
         ccm.configure(props);
-        map = JCS.getInstance(region);
-        this.cacheFallback = options.getCacheFallback();
+        map = JCS.getInstance("default");
     }
 
     /**
-     * Derives a stable, filesystem- and JCS-safe key from the server URI. The
-     * key is deterministic across restarts so a server reattaches to its own
-     * on-disk cache. A short hash of the full URI is appended so that URIs that
-     * sanitise to the same token do not collide.
+     * Acquires the disk-cache location for this JVM. The lock on
+     * {@code <loc>/lockFile} has three outcomes, distinguished by the fact that
+     * a Java {@link FileLock} is JVM-scoped:
+     * <ul>
+     *   <li>{@code tryLock()} returns a lock &rarr; nobody holds it; this mount
+     *       owns the location and keeps the lock.</li>
+     *   <li>{@link OverlappingFileLockException} &rarr; another mount in
+     *       <em>this</em> JVM already holds it (a foreign process would instead
+     *       yield {@code null}); share the location, taking no lock.</li>
+     *   <li>{@code tryLock()} returns {@code null} &rarr; another <em>process</em>
+     *       holds it; spill to {@code <loc>-N} if allowed, else fail.</li>
+     * </ul>
+     * The lock is only a cross-JVM guard. Note: it is held by whichever mount
+     * acquires it first and released when <em>that</em> mount closes, not when
+     * the last sharer closes.
      *
-     * @param serverURI the resolved full server URI
-     * @return the per-server cache key
+     * @return the resolved disk-cache location
+     * @throws IOException if no usable location can be locked
      */
-    private static String regionKey(URI serverURI) {
-        String raw = serverURI.toString();
-        String sanitized = raw.replaceAll("[^A-Za-z0-9_]", "_");
-        if (sanitized.length() > 64) {
-            sanitized = sanitized.substring(sanitized.length() - 64);
-        }
-        return sanitized + "_" + shortHash(raw);
-    }
-
-    private static String shortHash(String value) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < 4; i++) {
-                sb.append(String.format("%02x", digest[i]));
+    private Path lockCacheLocation() throws IOException {
+        Path cacheLocation = RestFileSystemOptionsHelper.getGlobalCacheLocation();
+        boolean allowAlternate = RestFileSystemOptionsHelper.allowAlternateCacheLocation();
+        for (int n = 1; n < 100; n++) {
+            Files.createDirectories(cacheLocation);
+            if (!(Files.isDirectory(cacheLocation) || Files.isWritable(cacheLocation))) {
+                throw new IOException("Invalid cache location: " + cacheLocation);
             }
-            return sb.toString();
-        } catch (NoSuchAlgorithmException x) {
-            // SHA-256 is guaranteed to be available on every JVM.
-            throw new IllegalStateException(x);
+            Path lockFile = cacheLocation.resolve("lockFile");
+            FileChannel lockFileChannel = FileChannel.open(lockFile, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+            try {
+                lock = lockFileChannel.tryLock();
+                if (lock != null) {
+                    return cacheLocation;
+                }
+                // Another process holds the lock on this location.
+                lockFileChannel.close();
+                if (!allowAlternate) {
+                    throw new IOException("Cache already in use: " + cacheLocation);
+                }
+                cacheLocation = cacheLocation.resolveSibling(cacheLocation.getFileName() + "-" + n);
+            } catch (OverlappingFileLockException x) {
+                // Another mount in this JVM already holds the lock; share the location.
+                lockFileChannel.close();
+                return cacheLocation;
+            }
         }
+        throw new IOException("Cache already in use and unable to get alternate cache location");
     }
 
     /**
-     * Returns the JCS region name used by this cache. Distinct remote file
-     * systems have distinct regions.
-     *
-     * @return the per-server region name
-     */
-    String getRegion() {
-        return region;
-    }
-
-    /**
-     * Returns the resolved per-server disk cache directory, or {@code null}
-     * when no disk cache is in use.
+     * Returns the resolved disk cache directory, or {@code null} when no disk
+     * cache is in use.
      *
      * @return the disk cache directory, or {@code null}
      */
@@ -178,20 +134,8 @@ class Cache implements Closeable {
         return diskCacheLocation;
     }
 
-    void setCacheFallbackOption(RestFileSystemOptions.CacheFallback cacheFallback) {
-        this.cacheFallback = cacheFallback;
-    }
-    
-    boolean doEntriesExpire() {
-        return cacheFallback != RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE;
-    }
-    
     CacheEntry getEntry(URI uri) {
-        CacheEntry e = map.get(uri);
-        if ( e != null ) {
-            e.setIsExpired(doEntriesExpire());
-        }
-        return e;
+        return map.get(uri);
     }
 
     void cacheResponse(ClientResponseContext response, URI uri) throws IOException {
@@ -202,9 +146,9 @@ class Cache implements Closeable {
     public void close() throws IOException {
         // This is super ugly, but otherwise we always get a SEVERE error because
         // the cache manager appears to shutdown the auxilliary disk cache once when it shuts
-        // down the memory cache, and then again when it shuts down the auxilliary caches. This 
+        // down the memory cache, and then again when it shuts down the auxilliary caches. This
         // looks like a bug, so here we turn off logging to avoid confusing messsages.
-        
+
         Logger logger = Logger.getLogger(IndexedDiskCache.class.getName());
         logger.setLevel(Level.OFF);
 
@@ -226,7 +170,6 @@ class Cache implements Closeable {
         private String mediaType;
         private byte[] bytes;
         private volatile int updateCount = 0;
-        private boolean isExpired = true;
 
         static final long serialVersionUID = 1521062449875932852L;
 
@@ -256,22 +199,6 @@ class Cache implements Closeable {
             response.setEntityStream(new ByteArrayInputStream(bytes));
         }
 
-        /**
-         * Expired indicates that the cache entry should be checked for freshness before
-         * use. The current implementation always returns true, meaning we always go back to
-         * the server (if it is online) to check that the cache entry is up-to-date. It would
-         * be possible to return false if the cache was recently created/updated, to reduce the need
-         * to constantly check the freshness of the cache if the same data is read repeatedly.
-         * @return <code>true</code> if the cache entry should be checked.
-         */
-        boolean isExpired() {
-            return isExpired;
-        }
-        
-        void setIsExpired(boolean isExpired) {
-            this.isExpired = isExpired;
-        }
-
         byte[] getContent() {
             return bytes;
         }
@@ -288,7 +215,7 @@ class Cache implements Closeable {
             return lastModified;
         }
 
-        /** 
+        /**
          * Called when the cache entry has been checked, and found to be up-to-date.
          * @param response The server response, used to extract the eTag and lastModified date.
          */

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
@@ -95,8 +95,9 @@ class Cache implements Closeable {
      * @throws IOException if no usable location can be locked
      */
     private Path lockCacheLocation() throws IOException {
-        Path cacheLocation = RestFileSystemOptionsHelper.getGlobalCacheLocation();
+        Path base = RestFileSystemOptionsHelper.getGlobalCacheLocation();
         boolean allowAlternate = RestFileSystemOptionsHelper.allowAlternateCacheLocation();
+        Path cacheLocation = base;
         for (int n = 1; n < 100; n++) {
             Files.createDirectories(cacheLocation);
             if (!(Files.isDirectory(cacheLocation) || Files.isWritable(cacheLocation))) {
@@ -114,7 +115,10 @@ class Cache implements Closeable {
                 if (!allowAlternate) {
                     throw new IOException("Cache already in use: " + cacheLocation);
                 }
-                cacheLocation = cacheLocation.resolveSibling(cacheLocation.getFileName() + "-" + n);
+                // Spill to a flat sibling of the base (<base>-1, <base>-2, …); suffix
+                // the pristine base, not the already-suffixed candidate, or the names
+                // compound (<base>-1-2-3).
+                cacheLocation = base.resolveSibling(base.getFileName() + "-" + n);
             } catch (OverlappingFileLockException x) {
                 // Another mount in this JVM already holds the lock; share the location.
                 lockFileChannel.close();

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/Cache.java
@@ -10,9 +10,12 @@ import java.net.URI;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -35,14 +38,26 @@ class Cache implements Closeable {
     private CacheAccess<URI, CacheEntry> map;
     private FileLock lock;
     private RestFileSystemOptions.CacheFallback cacheFallback;
+    private final String region;
+    private Path diskCacheLocation;
 
     /**
      * Creates a new cache instance based on the supplied options.
+     * <p>
+     * Each remote file system gets its own JCS region and (for
+     * {@code MEMORY_AND_DISK}) its own disk directory, both derived from a
+     * stable key computed from {@code serverURI}. This keeps the caches of
+     * multiple file systems in the same JVM fully isolated, so they neither
+     * share a region nor collide on the disk lock.
      *
      * @param options user supplied configuration
+     * @param serverURI the resolved full URI of the server (server root plus
+     *                   mount point) used to derive the per-server cache key
      * @throws IOException if the cache cannot be initialised
      */
-    Cache(RestFileSystemOptionsHelper options) throws IOException {
+    Cache(RestFileSystemOptionsHelper options, URI serverURI) throws IOException {
+
+        this.region = regionKey(serverURI);
 
         JCS.setLogSystem(LogManager.LOGSYSTEM_JAVA_UTIL_LOGGING);
 
@@ -56,11 +71,22 @@ class Cache implements Closeable {
             props.load(in);
         }
         if (options.getCacheOptions() == RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK) {
+            String aux = "DC_" + region;
+            Properties diskProps = new Properties();
             try ( InputStream in = Cache.class.getResourceAsStream("disk.ccf")) {
-                props.load(in);
+                diskProps.load(in);
             }
-            Path cacheLocation = options.getDiskCacheLocation();
-            if (cacheLocation != null) {
+            // Substitute the per-server region and auxiliary names into the disk template.
+            for (String name : diskProps.stringPropertyNames()) {
+                String key = name.replace("%REGION%", region).replace("%AUX%", aux);
+                String value = diskProps.getProperty(name).replace("%REGION%", region).replace("%AUX%", aux);
+                props.setProperty(key, value);
+            }
+            Path baseLocation = options.getDiskCacheLocation();
+            if (baseLocation != null) {
+                // Each server caches under its own subdirectory of the configured base
+                // location, so distinct servers never contend for the same disk lock.
+                Path cacheLocation = baseLocation.resolve(region);
                 // Check that we can lock the cache, and if not what to do about it
                 for (int n = 1; n < 100; n++) {
                     Files.createDirectories(cacheLocation);
@@ -89,13 +115,67 @@ class Cache implements Closeable {
                     throw new IOException("Cache already in use and unable to get alternate cache location");
                 }
 
-                props.setProperty("jcs.auxiliary.DC.attributes.DiskPath", cacheLocation.toAbsolutePath().toString());
+                this.diskCacheLocation = cacheLocation;
+                props.setProperty("jcs.auxiliary." + aux + ".attributes.DiskPath", cacheLocation.toAbsolutePath().toString());
             }
         }
         CompositeCacheManager ccm = CompositeCacheManager.getUnconfiguredInstance();
         ccm.configure(props);
-        map = JCS.getInstance("default");        
+        map = JCS.getInstance(region);
         this.cacheFallback = options.getCacheFallback();
+    }
+
+    /**
+     * Derives a stable, filesystem- and JCS-safe key from the server URI. The
+     * key is deterministic across restarts so a server reattaches to its own
+     * on-disk cache. A short hash of the full URI is appended so that URIs that
+     * sanitise to the same token do not collide.
+     *
+     * @param serverURI the resolved full server URI
+     * @return the per-server cache key
+     */
+    private static String regionKey(URI serverURI) {
+        String raw = serverURI.toString();
+        String sanitized = raw.replaceAll("[^A-Za-z0-9_]", "_");
+        if (sanitized.length() > 64) {
+            sanitized = sanitized.substring(sanitized.length() - 64);
+        }
+        return sanitized + "_" + shortHash(raw);
+    }
+
+    private static String shortHash(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < 4; i++) {
+                sb.append(String.format("%02x", digest[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException x) {
+            // SHA-256 is guaranteed to be available on every JVM.
+            throw new IllegalStateException(x);
+        }
+    }
+
+    /**
+     * Returns the JCS region name used by this cache. Distinct remote file
+     * systems have distinct regions.
+     *
+     * @return the per-server region name
+     */
+    String getRegion() {
+        return region;
+    }
+
+    /**
+     * Returns the resolved per-server disk cache directory, or {@code null}
+     * when no disk cache is in use.
+     *
+     * @return the disk cache directory, or {@code null}
+     */
+    Path getDiskCacheLocation() {
+        return diskCacheLocation;
     }
 
     void setCacheFallbackOption(RestFileSystemOptions.CacheFallback cacheFallback) {

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/CacheRequestFilter.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/CacheRequestFilter.java
@@ -17,19 +17,36 @@ import org.lsst.ccs.rest.file.server.client.implementation.Cache.CacheEntry;
 class CacheRequestFilter implements ClientRequestFilter {
 
     private final Cache cache;
-    private final boolean cacheOnly;
+    private boolean cacheOnly;
+    private boolean doEntriesExpire;
 
     /**
      * Creates a filter that serves requests from the local cache when
-     * possible.
+     * possible. This filter owns the per-mount freshness policy, which used to
+     * live in {@code Cache} (see ADR 0003).
      *
      * @param cache the backing cache
      * @param cacheOnly {@code true} to avoid contacting the server and rely
      *                  solely on cached data
+     * @param doEntriesExpire {@code true} if cached entries must be revalidated
+     *                  against the server; {@code false} serves them directly
+     *                  (the immutable-URL / {@code WHEN_POSSIBLE} case)
      */
-    CacheRequestFilter(Cache cache, boolean cacheOnly) {
+    CacheRequestFilter(Cache cache, boolean cacheOnly, boolean doEntriesExpire) {
         this.cache = cache;
         this.cacheOnly = cacheOnly;
+        this.doEntriesExpire = doEntriesExpire;
+    }
+
+    /**
+     * Updates the per-mount freshness policy after construction.
+     *
+     * @param cacheOnly {@code true} to rely solely on cached data
+     * @param doEntriesExpire {@code true} to revalidate cached entries
+     */
+    void setPolicy(boolean cacheOnly, boolean doEntriesExpire) {
+        this.cacheOnly = cacheOnly;
+        this.doEntriesExpire = doEntriesExpire;
     }
 
     @Override
@@ -49,7 +66,7 @@ class CacheRequestFilter implements ClientRequestFilter {
             return;
         }
 
-        if (!entry.isExpired() || cacheOnly) {
+        if (!doEntriesExpire || cacheOnly) {
             ByteArrayInputStream is = new ByteArrayInputStream(entry.getContent());
             Response response = Response.ok(is).type(entry.getContentType()).build();
             ctx.abortWith(response);

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
@@ -73,9 +73,9 @@ public class RestFileSystem extends AbstractFileSystem implements AbstractPathBu
             cache = null;
         }
         client.register(new AddProtcolVersionRequestFilter());
-        Object jwt = env.get(RestFileSystemOptions.AUTH_TOKEN);
+        String jwt = options.getAuthToken();
         if (jwt != null) {
-            client.register(new AddJWTTokenRequestFilter(jwt.toString()));
+            client.register(new AddJWTTokenRequestFilter(jwt));
         }
         restClient = new RestClient(client, restURI, mountPoint);
     }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
@@ -45,6 +45,7 @@ public class RestFileSystem extends AbstractFileSystem implements AbstractPathBu
     private final RestFileSystemOptionsHelper options;
     private final RestClient restClient;
     private final Cache cache;
+    private final CacheRequestFilter cacheRequestFilter;
     private boolean offline = false;
     private static final Logger LOG = Logger.getLogger(RestFileSystem.class.getName());
     private final URI mountPoint;
@@ -66,11 +67,14 @@ public class RestFileSystem extends AbstractFileSystem implements AbstractPathBu
         Client client = ClientBuilder.newBuilder().readTimeout(3, TimeUnit.SECONDS).connectTimeout(3, TimeUnit.SECONDS).build();
         final URI restURI = computeRestURI(client);
         if (options.getCacheOptions() != RestFileSystemOptions.CacheOptions.NONE) {
-            cache = new Cache(options, getFullURI());
-            client.register(new CacheRequestFilter(cache, offline || options.getCacheFallback() == RestFileSystemOptions.CacheFallback.ALWAYS));
+            cache = new Cache(options);
+            RestFileSystemOptions.CacheFallback fallback = options.getCacheFallback();
+            cacheRequestFilter = new CacheRequestFilter(cache, isCacheOnly(fallback), doEntriesExpire(fallback));
+            client.register(cacheRequestFilter);
             client.register(new CacheResponseFilter(cache));
         } else {
             cache = null;
+            cacheRequestFilter = null;
         }
         client.register(new AddProtcolVersionRequestFilter());
         String jwt = options.getAuthToken();
@@ -117,6 +121,27 @@ public class RestFileSystem extends AbstractFileSystem implements AbstractPathBu
     
     Cache getCache() {
         return cache;
+    }
+
+    private boolean isCacheOnly(RestFileSystemOptions.CacheFallback fallback) {
+        return offline || fallback == RestFileSystemOptions.CacheFallback.ALWAYS;
+    }
+
+    private static boolean doEntriesExpire(RestFileSystemOptions.CacheFallback fallback) {
+        return fallback != RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE;
+    }
+
+    /**
+     * Updates the cache freshness policy for this mount at runtime. Policy is
+     * per-mount and lives in the request filter (see ADR 0003); this recomputes
+     * the filter's flags from the given fallback.
+     *
+     * @param fallback the cache fallback policy to apply
+     */
+    void setCacheFallbackOption(RestFileSystemOptions.CacheFallback fallback) {
+        if (cacheRequestFilter != null) {
+            cacheRequestFilter.setPolicy(isCacheOnly(fallback), doEntriesExpire(fallback));
+        }
     }
     
     RestClient getClient() {

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystem.java
@@ -66,7 +66,7 @@ public class RestFileSystem extends AbstractFileSystem implements AbstractPathBu
         Client client = ClientBuilder.newBuilder().readTimeout(3, TimeUnit.SECONDS).connectTimeout(3, TimeUnit.SECONDS).build();
         final URI restURI = computeRestURI(client);
         if (options.getCacheOptions() != RestFileSystemOptions.CacheOptions.NONE) {
-            cache = new Cache(options);
+            cache = new Cache(options, getFullURI());
             client.register(new CacheRequestFilter(cache, offline || options.getCacheFallback() == RestFileSystemOptions.CacheFallback.ALWAYS));
             client.register(new CacheResponseFilter(cache));
         } else {

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -25,15 +26,31 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 
     /**
      * Creates a new helper.
+     * <p>
+     * Options are resolved per key with the following precedence, highest
+     * first: the explicitly supplied {@code env}, then the programmatic default
+     * set via {@link RestFileSystemOptions#setDefaultFileSystemEnvironment}, then
+     * the {@link RestFileSystemOptions#DEFAULT_ENV_PROPERTY} system-property JSON
+     * map, and finally the hardcoded fallback applied by {@link #getOption}. A
+     * key present at a higher level overrides the same key at a lower level; keys
+     * absent at a higher level fall through.
      *
      * @param env environment map supplied to the file system; may be {@code null}
      */
     RestFileSystemOptionsHelper(Map<String, ?> env) {
-        if (env == null) {
-            this.env = createDefaultOptions();
-        } else {
-            this.env = env;
+        Map<String, Object> merged = new HashMap<>();
+        Map<String, ?> propertyDefaults = createDefaultOptions();
+        if (propertyDefaults != null) {
+            merged.putAll(propertyDefaults);
         }
+        Map<String, ?> programmaticDefaults = RestFileSystemProvider.getDefaultFileSystemOption();
+        if (programmaticDefaults != null) {
+            merged.putAll(programmaticDefaults);
+        }
+        if (env != null) {
+            merged.putAll(env);
+        }
+        this.env = merged;
     }
 
     /**
@@ -52,6 +69,16 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
      */
     RestFileSystemOptions.SSLOptions isUseSSL() {
         return getOption(RestFileSystemOptions.USE_SSL, RestFileSystemOptions.SSLOptions.class, RestFileSystemOptions.SSLOptions.AUTO);
+    }
+
+    /**
+     * Returns the JWT authorization token, resolved through the option cascade.
+     *
+     * @return the token, or {@code null} if none was configured
+     */
+    String getAuthToken() {
+        Object result = env.get(RestFileSystemOptions.AUTH_TOKEN);
+        return result == null ? null : result.toString();
     }
 
     /**

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
@@ -123,10 +123,30 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
         } else if (result instanceof File) {
             return ((File) result).toPath();
         } else if (result instanceof String) {
-            return Paths.get((String) result);
+            return Paths.get(expandTilde((String) result)).normalize();
         } else {
             throw new IllegalArgumentException("Invalid value for option " + RestFileSystemOptions.CACHE_LOCATION + ": " + result);
         }
+    }
+
+    /**
+     * Expands a leading {@code ~} to the user's home directory. Unlike a shell,
+     * Java does not resolve {@code ~} in a path string, so a value that reaches
+     * us unexpanded (e.g. from the {@link RestFileSystemOptions#DEFAULT_ENV_PROPERTY}
+     * JSON map) must be handled here. Only a leading {@code ~} (alone or followed
+     * by a separator) is expanded; {@code ~user} and non-leading tildes are left
+     * untouched.
+     *
+     * @param path the raw path string
+     * @return the path with a leading {@code ~} replaced by {@code user.home}
+     */
+    private static String expandTilde(String path) {
+        if (path.equals("~")) {
+            return System.getProperty("user.home");
+        } else if (path.startsWith("~/")) {
+            return System.getProperty("user.home") + path.substring(1);
+        }
+        return path;
     }
 
     /**

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemOptionsHelper.java
@@ -39,7 +39,7 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
      */
     RestFileSystemOptionsHelper(Map<String, ?> env) {
         Map<String, Object> merged = new HashMap<>();
-        Map<String, ?> propertyDefaults = createDefaultOptions();
+        Map<String, ?> propertyDefaults = parseDefaultEnvProperty();
         if (propertyDefaults != null) {
             merged.putAll(propertyDefaults);
         }
@@ -100,46 +100,132 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
     }
 
     /**
-     * Specifies whether alternate cache locations are permitted if the primary
-     * location is unavailable.
+     * The on-disk cache location and the spill flag ({@code CacheFallbackLocation})
+     * describe the single per-JVM cache (see ADR 0003), so they are resolved
+     * globally and once, not per file system. See
+     * {@link #getGlobalCacheLocation()} and {@link #allowAlternateCacheLocation()}.
+     * The per-file-system {@code env} is deliberately not consulted for these two
+     * keys, which is what makes a per-FS {@code cacheLocation()} /
+     * {@code ignoreLockedCache()} inert.
+     */
+
+    /** Built-in default cache location when nothing else supplies one. */
+    private static final String DEFAULT_CACHE_LOCATION = "~/ccs/cache/default";
+
+    // The global cache config is resolved once (before the first file system)
+    // and memoized. A test backdoor can seed/reset it; see
+    // setGlobalCacheConfigForTest / resetGlobalCacheConfigForTest.
+    private static Path globalCacheLocation;
+    private static boolean globalAllowAlternate;
+    private static boolean globalResolved = false;
+
+    // Programmatic location override (e.g. the CLI's --cacheDir), allowed only
+    // before the cache is configured. Takes precedence over the property; the
+    // spill flag still resolves normally.
+    private static Path cacheLocationOverride;
+
+    /**
+     * Resolves the JVM-global cache location, once. Resolution order, highest
+     * precedence first: the test backdoor, the {@link RestFileSystemOptions#DEFAULT_ENV_PROPERTY}
+     * JSON map, then the built-in default {@value #DEFAULT_CACHE_LOCATION}. A
+     * leading {@code ~} is expanded and the path normalized.
+     *
+     * @return the resolved global cache location, never {@code null}
+     */
+    static synchronized Path getGlobalCacheLocation() {
+        resolveGlobalCacheConfig();
+        return globalCacheLocation;
+    }
+
+    /**
+     * Indicates whether the cache may spill to an alternate location
+     * ({@code <name>-N}) when another process holds the lock on the resolved
+     * location. JVM-global; resolved from the {@code CacheFallbackLocation} key
+     * of the {@link RestFileSystemOptions#DEFAULT_ENV_PROPERTY} map, default
+     * {@code false}.
      *
      * @return {@code true} if alternate locations are allowed
      */
-    boolean allowAlternateCacheLoction() {
-        return getOption(RestFileSystemOptions.ALLOW_ALTERNATE_CACHE_LOCATION, Boolean.class, Boolean.FALSE);
+    static synchronized boolean allowAlternateCacheLocation() {
+        resolveGlobalCacheConfig();
+        return globalAllowAlternate;
+    }
+
+    private static void resolveGlobalCacheConfig() {
+        if (globalResolved) {
+            return;
+        }
+        Map<String, ?> defaults = parseDefaultEnvProperty();
+        // Location precedence: programmatic override, then the property, then the
+        // built-in default. The spill flag always resolves from the property.
+        Object location = cacheLocationOverride != null ? cacheLocationOverride
+                : (defaults == null ? null : defaults.get(RestFileSystemOptions.CACHE_LOCATION));
+        globalCacheLocation = toPath(location != null ? location : DEFAULT_CACHE_LOCATION);
+        Object allow = defaults == null ? null : defaults.get(RestFileSystemOptions.ALLOW_ALTERNATE_CACHE_LOCATION);
+        globalAllowAlternate = allow != null && Boolean.parseBoolean(allow.toString());
+        globalResolved = true;
     }
 
     /**
-     * Provides the location of the on-disk cache if configured.
+     * Pins a programmatic cache-location override, allowed only while the cache
+     * is still unconfigured (before the first file system is created). Once a
+     * cache has been configured the location is fixed for the JVM, so a later
+     * call fails rather than silently having no effect. Backs
+     * {@link RestFileSystemOptions#setCacheLocation(Path)}.
      *
-     * @return path to the disk cache or {@code null} if none
+     * @param location the cache location to use for this JVM
+     * @throws IllegalStateException if the cache location is already configured
      */
-    Path getDiskCacheLocation() {
-        Object result = env.get(RestFileSystemOptions.CACHE_LOCATION);
-        if (result == null) {
-            return null;
-        } else if (result instanceof Path) {
-            return (Path) result;
-        } else if (result instanceof File) {
-            return ((File) result).toPath();
-        } else if (result instanceof String) {
-            return Paths.get(expandTilde((String) result)).normalize();
+    static synchronized void setCacheLocationOverride(Path location) {
+        if (globalResolved) {
+            throw new IllegalStateException("Cache location cannot be set: the cache is already configured at " + globalCacheLocation);
+        }
+        cacheLocationOverride = location;
+    }
+
+    /**
+     * Seeds the JVM-global cache config directly, bypassing the system property.
+     * For tests only, so they need not manipulate a global {@code -D} — set a
+     * per-test temp location here and {@link #resetGlobalCacheConfigForTest()}
+     * afterwards.
+     *
+     * @param location the cache location to use
+     * @param allowAlternate whether spill to an alternate location is allowed
+     */
+    static synchronized void setGlobalCacheConfigForTest(Path location, boolean allowAlternate) {
+        globalCacheLocation = location;
+        globalAllowAlternate = allowAlternate;
+        globalResolved = true;
+    }
+
+    /** Clears the memoized global cache config so it is re-resolved. Tests must call this to avoid leaking state. */
+    static synchronized void resetGlobalCacheConfigForTest() {
+        globalCacheLocation = null;
+        globalAllowAlternate = false;
+        globalResolved = false;
+        cacheLocationOverride = null;
+    }
+
+    /**
+     * Converts a cache-location option value ({@link Path}, {@link File}, or a
+     * {@link String} with a leading {@code ~} and {@code .}/{@code ..} segments)
+     * to a normalized {@link Path}. Java has no shell {@code ~} expansion, so a
+     * string value (e.g. from the JSON property or the built-in default) is
+     * expanded here; only a leading {@code ~} or {@code ~/} is expanded,
+     * {@code ~user} is left untouched.
+     */
+    private static Path toPath(Object value) {
+        if (value instanceof Path) {
+            return (Path) value;
+        } else if (value instanceof File) {
+            return ((File) value).toPath();
+        } else if (value instanceof String) {
+            return Paths.get(expandTilde((String) value)).normalize();
         } else {
-            throw new IllegalArgumentException("Invalid value for option " + RestFileSystemOptions.CACHE_LOCATION + ": " + result);
+            throw new IllegalArgumentException("Invalid value for option " + RestFileSystemOptions.CACHE_LOCATION + ": " + value);
         }
     }
 
-    /**
-     * Expands a leading {@code ~} to the user's home directory. Unlike a shell,
-     * Java does not resolve {@code ~} in a path string, so a value that reaches
-     * us unexpanded (e.g. from the {@link RestFileSystemOptions#DEFAULT_ENV_PROPERTY}
-     * JSON map) must be handled here. Only a leading {@code ~} (alone or followed
-     * by a separator) is expanded; {@code ~user} and non-leading tildes are left
-     * untouched.
-     *
-     * @param path the raw path string
-     * @return the path with a leading {@code ~} replaced by {@code user.home}
-     */
     private static String expandTilde(String path) {
         if (path.equals("~")) {
             return System.getProperty("user.home");
@@ -187,7 +273,7 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
         throw new IllegalArgumentException("Invalid value for option " + optionName + ": " + result);
     }
 
-    private Map<String, ?> createDefaultOptions() {
+    private static Map<String, ?> parseDefaultEnvProperty() {
         String defaultOptions = System.getProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY);
         if (defaultOptions != null) {
             ObjectMapper objectMapper = new ObjectMapper();
@@ -195,8 +281,8 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
                 return objectMapper.readValue(defaultOptions, new TypeReference<Map<String,Object>>(){});
             } catch (JsonProcessingException x) {
                 LOG.log(Level.WARNING, "Unable to parse default rest server options: "+defaultOptions, x);
-            }        
-        } 
+            }
+        }
         return null;
     }
 }

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemProvider.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemProvider.java
@@ -61,7 +61,17 @@ public class RestFileSystemProvider extends FileSystemProvider {
     public static void setDefaultFileSystemOption(Map<String, ?> defaultEnv) {
         defaultEnvironment = defaultEnv;
     }
-    
+
+    /**
+     * Returns the programmatic default options set via
+     * {@link #setDefaultFileSystemOption}, or {@code null} if none were set.
+     *
+     * @return the default environment map, or {@code null}
+     */
+    static Map<String, ?> getDefaultFileSystemOption() {
+        return defaultEnvironment;
+    }
+
     @Override
     public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
         if (env == null) {

--- a/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemProvider.java
+++ b/client/src/main/java/org/lsst/ccs/rest/file/server/client/implementation/RestFileSystemProvider.java
@@ -72,6 +72,18 @@ public class RestFileSystemProvider extends FileSystemProvider {
         return defaultEnvironment;
     }
 
+    /**
+     * Pins the JVM-global cache location, allowed only before the cache is
+     * configured (see {@link RestFileSystemOptions#setCacheLocation}). Bridges
+     * from the public API to the package-private resolver.
+     *
+     * @param location the cache location to use for this JVM
+     * @throws IllegalStateException if the cache location is already configured
+     */
+    public static void setCacheLocation(java.nio.file.Path location) {
+        RestFileSystemOptionsHelper.setCacheLocationOverride(location);
+    }
+
     @Override
     public FileSystem newFileSystem(URI uri, Map<String, ?> env) throws IOException {
         if (env == null) {

--- a/client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/disk.ccf
+++ b/client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/disk.ccf
@@ -1,14 +1,12 @@
-# PER-SERVER DISK CACHE
-# %REGION% and %AUX% are substituted per remote file system by Cache.java so that
-# each server gets its own region backed by its own disk auxiliary and DiskPath.
-# The DiskPath attribute is set programmatically (per-server directory) rather than here.
-jcs.region.%REGION%=%AUX%
+# DEFAULT CACHE REGION
+jcs.default=DC
 
 # AVAILABLE AUXILIARY CACHES
-jcs.auxiliary.%AUX%=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheFactory
-jcs.auxiliary.%AUX%.attributes=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheAttributes
-jcs.auxiliary.%AUX%.attributes.MaxPurgatorySize=10000000
-jcs.auxiliary.%AUX%.attributes.MaxKeySize=1000000
-jcs.auxiliary.%AUX%.attributes.OptimizeAtRemoveCount=300000
-jcs.auxiliary.%AUX%.attributes.ShutdownSpoolTimeLimit=60
-jcs.auxiliary.%AUX%.cacheattributes.DiskUsagePatternName=UPDATE
+# DiskPath is set programmatically per JVM by Cache.java (the resolved global cache location).
+jcs.auxiliary.DC=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheFactory
+jcs.auxiliary.DC.attributes=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheAttributes
+jcs.auxiliary.DC.attributes.MaxPurgatorySize=10000000
+jcs.auxiliary.DC.attributes.MaxKeySize=1000000
+jcs.auxiliary.DC.attributes.OptimizeAtRemoveCount=300000
+jcs.auxiliary.DC.attributes.ShutdownSpoolTimeLimit=60
+jcs.auxiliary.DC.cacheattributes.DiskUsagePatternName=UPDATE

--- a/client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/disk.ccf
+++ b/client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/disk.ccf
@@ -1,12 +1,14 @@
-# DEFAULT CACHE REGION
-jcs.default=DC
+# PER-SERVER DISK CACHE
+# %REGION% and %AUX% are substituted per remote file system by Cache.java so that
+# each server gets its own region backed by its own disk auxiliary and DiskPath.
+# The DiskPath attribute is set programmatically (per-server directory) rather than here.
+jcs.region.%REGION%=%AUX%
 
 # AVAILABLE AUXILIARY CACHES
-jcs.auxiliary.DC=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheFactory
-jcs.auxiliary.DC.attributes=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheAttributes
-jcs.auxiliary.DC.attributes.DiskPath=${user.home}/jcs_swap
-jcs.auxiliary.DC.attributes.MaxPurgatorySize=10000000
-jcs.auxiliary.DC.attributes.MaxKeySize=1000000
-jcs.auxiliary.DC.attributes.OptimizeAtRemoveCount=300000
-jcs.auxiliary.DC.attributes.ShutdownSpoolTimeLimit=60
-jcs.auxiliary.DC.cacheattributes.DiskUsagePatternName=UPDATE
+jcs.auxiliary.%AUX%=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheFactory
+jcs.auxiliary.%AUX%.attributes=org.apache.commons.jcs3.auxiliary.disk.indexed.IndexedDiskCacheAttributes
+jcs.auxiliary.%AUX%.attributes.MaxPurgatorySize=10000000
+jcs.auxiliary.%AUX%.attributes.MaxKeySize=1000000
+jcs.auxiliary.%AUX%.attributes.OptimizeAtRemoveCount=300000
+jcs.auxiliary.%AUX%.attributes.ShutdownSpoolTimeLimit=60
+jcs.auxiliary.%AUX%.cacheattributes.DiskUsagePatternName=UPDATE

--- a/client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/memory.ccf
+++ b/client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/memory.ccf
@@ -1,7 +1,7 @@
 # DEFAULT CACHE REGION
 jcs.default=
 jcs.default.cacheattributes=org.apache.commons.jcs3.engine.CompositeCacheAttributes
-jcs.default.cacheattributes.MaxObjects=1000
+jcs.default.cacheattributes.MaxObjects=2500
 jcs.default.cacheattributes.MemoryCacheName=org.apache.commons.jcs3.engine.memory.lru.LRUMemoryCache
 jcs.default.cacheattributes.UseMemoryShrinker=false
 jcs.default.cacheattributes.MaxMemoryIdleTimeSeconds=3600

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CacheLockCrossJvmTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CacheLockCrossJvmTest.java
@@ -5,8 +5,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -14,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 
 /**
@@ -22,25 +24,32 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
  * {@code OverlappingFileLockException} (the share path, covered by
  * {@code CachingTest}). So this launches a real second JVM
  * ({@link CacheLockHolder}) that holds the lock on a location, then asserts this
- * JVM either spills to {@code <loc>-1} (spill enabled) or fails "in use" (spill
- * disabled). Linux-only; revisit if it proves flaky in CI.
+ * JVM either spills to a flat sibling {@code <loc>-N} (spill enabled) or fails
+ * "in use" (spill disabled). Linux-only; revisit if it proves flaky in CI.
  */
 public class CacheLockCrossJvmTest {
 
-    private Process holder;
+    private final List<Process> holders = new ArrayList<>();
+
+    /**
+     * JUnit creates this per test and deletes the tree afterwards. Deletion runs
+     * after {@link #tearDown()} force-kills the holder JVMs, so no process still
+     * holds files under it when it is removed.
+     */
+    @TempDir
+    Path tempDir;
 
     @AfterEach
     public void tearDown() {
-        if (holder != null) {
+        for (Process holder : holders) {
             holder.destroyForcibly();
-            holder = null;
         }
+        holders.clear();
         RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
     }
 
     @Test
     public void spillsToAlternateWhenAnotherProcessHoldsTheLock() throws Exception {
-        final Path tempDir = Files.createTempDirectory("rfs");
         final Path primary = tempDir.resolve("cache");
         startHolder(primary);
 
@@ -56,9 +65,31 @@ public class CacheLockCrossJvmTest {
         }
     }
 
+    /**
+     * Spilling twice must produce flat siblings {@code <loc>-1}, {@code <loc>-2} —
+     * not a compounding {@code <loc>-1-2}. Two foreign JVMs hold {@code cache} and
+     * {@code cache-1}; this JVM must therefore land on {@code cache-2}. Regression
+     * guard for the bug where the suffix was appended to the already-suffixed
+     * candidate rather than the base.
+     */
+    @Test
+    public void spillsToFlatSiblingsWhenWalkingPastMultipleLocks() throws Exception {
+        final Path primary = tempDir.resolve("cache");
+        startHolder(primary);
+        startHolder(primary.resolveSibling(primary.getFileName() + "-1"));
+
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(primary, true);
+        RestFileSystemOptionsHelper options = new RestFileSystemOptionsHelper(
+                RestFileSystemOptions.builder().set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK).build());
+        try (Cache cache = new Cache(options)) {
+            assertEquals(primary.resolveSibling(primary.getFileName() + "-2").toAbsolutePath(),
+                    cache.getDiskCacheLocation().toAbsolutePath(),
+                    "second spill must be <loc>-2, not a compounding <loc>-1-2");
+        }
+    }
+
     @Test
     public void failsInUseWhenSpillDisabled() throws Exception {
-        final Path tempDir = Files.createTempDirectory("rfs");
         final Path primary = tempDir.resolve("cache");
         startHolder(primary);
 
@@ -84,7 +115,8 @@ public class CacheLockCrossJvmTest {
                 javaBin, "-cp", System.getProperty("java.class.path"),
                 CacheLockHolder.class.getName(), location.toAbsolutePath().toString());
         pb.redirectErrorStream(true);
-        holder = pb.start();
+        Process holder = pb.start();
+        holders.add(holder);
 
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
         BufferedReader reader = new BufferedReader(new InputStreamReader(holder.getInputStream(), StandardCharsets.UTF_8));

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CacheLockCrossJvmTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CacheLockCrossJvmTest.java
@@ -1,0 +1,102 @@
+package org.lsst.ccs.rest.file.server.client.implementation;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
+
+/**
+ * Cross-JVM cache-lock guard (ADR 0003 §3). A single JVM cannot produce a
+ * genuine {@code tryLock()==null}; same-JVM contention always surfaces as an
+ * {@code OverlappingFileLockException} (the share path, covered by
+ * {@code CachingTest}). So this launches a real second JVM
+ * ({@link CacheLockHolder}) that holds the lock on a location, then asserts this
+ * JVM either spills to {@code <loc>-1} (spill enabled) or fails "in use" (spill
+ * disabled). Linux-only; revisit if it proves flaky in CI.
+ */
+public class CacheLockCrossJvmTest {
+
+    private Process holder;
+
+    @AfterEach
+    public void tearDown() {
+        if (holder != null) {
+            holder.destroyForcibly();
+            holder = null;
+        }
+        RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
+    }
+
+    @Test
+    public void spillsToAlternateWhenAnotherProcessHoldsTheLock() throws Exception {
+        final Path tempDir = Files.createTempDirectory("rfs");
+        final Path primary = tempDir.resolve("cache");
+        startHolder(primary);
+
+        // Spill enabled: this JVM must land on a sibling <loc>-N, not the primary.
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(primary, true);
+        RestFileSystemOptionsHelper options = new RestFileSystemOptionsHelper(
+                RestFileSystemOptions.builder().set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK).build());
+        try (Cache cache = new Cache(options)) {
+            assertNotEquals(primary.toAbsolutePath(), cache.getDiskCacheLocation().toAbsolutePath(),
+                    "should have spilled off the locked primary location");
+            assertEquals(primary.resolveSibling(primary.getFileName() + "-1").toAbsolutePath(),
+                    cache.getDiskCacheLocation().toAbsolutePath());
+        }
+    }
+
+    @Test
+    public void failsInUseWhenSpillDisabled() throws Exception {
+        final Path tempDir = Files.createTempDirectory("rfs");
+        final Path primary = tempDir.resolve("cache");
+        startHolder(primary);
+
+        // Spill disabled: this JVM must fail rather than spill.
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(primary, false);
+        RestFileSystemOptionsHelper options = new RestFileSystemOptionsHelper(
+                RestFileSystemOptions.builder().set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK).build());
+        try {
+            new Cache(options);
+            fail("expected 'in use' failure while another process holds the lock");
+        } catch (IOException x) {
+            assertTrue(x.getMessage().contains("in use"), x.getMessage());
+        }
+    }
+
+    /**
+     * Launches the lock-holder JVM on {@code location} and blocks until it prints
+     * its readiness marker (or fails/ times out).
+     */
+    private void startHolder(Path location) throws IOException, InterruptedException {
+        String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        ProcessBuilder pb = new ProcessBuilder(
+                javaBin, "-cp", System.getProperty("java.class.path"),
+                CacheLockHolder.class.getName(), location.toAbsolutePath().toString());
+        pb.redirectErrorStream(true);
+        holder = pb.start();
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(holder.getInputStream(), StandardCharsets.UTF_8));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (line.contains(CacheLockHolder.READY_MARKER)) {
+                return;
+            }
+            if (System.nanoTime() > deadline) {
+                break;
+            }
+        }
+        fail("lock-holder process did not become ready");
+    }
+}

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CacheLockHolder.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CacheLockHolder.java
@@ -1,0 +1,39 @@
+package org.lsst.ccs.rest.file.server.client.implementation;
+
+import java.nio.file.Paths;
+import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
+
+/**
+ * Test helper launched as a separate JVM by {@link CacheLockCrossJvmTest}. It
+ * opens a {@code MEMORY_AND_DISK} {@link Cache} at the location given in argv[0],
+ * which takes the cross-JVM lock, prints a readiness marker, then blocks until
+ * the parent kills it. A safety timeout guarantees it cannot linger and hold the
+ * lock forever if the parent fails to tear it down.
+ */
+public class CacheLockHolder {
+
+    /** Printed on stdout once the lock is held, so the parent can proceed. */
+    static final String READY_MARKER = "LOCK_HELD";
+
+    public static void main(String[] args) throws Exception {
+        String location = args[0];
+        // Deliver the location the same way production does: the global config
+        // property. Spill off, so this process takes the primary location.
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY,
+                "{\"CacheOptions\":\"MEMORY_AND_DISK\",\"CacheLocation\":\"" + location + "\"}");
+
+        RestFileSystemOptionsHelper options = new RestFileSystemOptionsHelper(null);
+        try (Cache cache = new Cache(options)) {
+            // Confirm we actually landed on the requested location (no spill).
+            if (!Paths.get(location).toAbsolutePath().equals(cache.getDiskCacheLocation().toAbsolutePath())) {
+                System.out.println("UNEXPECTED_LOCATION " + cache.getDiskCacheLocation());
+                return;
+            }
+            System.out.println(READY_MARKER);
+            System.out.flush();
+            // Hold the lock until killed, with a safety cap so a leaked process
+            // releases the lock on its own.
+            Thread.sleep(60_000);
+        }
+    }
+}

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CachingTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CachingTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 import org.lsst.ccs.rest.file.server.client.implementation.Cache.CacheEntry;
 import org.lsst.ccs.web.rest.file.server.TestServer;
@@ -30,6 +31,10 @@ import org.lsst.ccs.web.rest.file.server.TestServer;
  * @author tonyj
  */
 public class CachingTest {
+
+    /** JUnit creates this per test and deletes the tree afterwards, so the cache dir does not leak. */
+    @TempDir
+    Path tempDir;
 
     /**
      * The cache location is JVM-global (ADR 0003). Tests point it at a temp dir
@@ -53,7 +58,6 @@ public class CachingTest {
     public void cacheTest(int port, RestFileSystemOptions.CacheFallback cacheMode) throws URISyntaxException, IOException, InterruptedException {
         TestServer testServer = new TestServer(port);
         URI restRootURI = UriBuilder.fromUri(testServer.getServerURI()).scheme("ccs").build();
-        final Path tempDir = Files.createTempDirectory("rfs");
         RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         Map<String, Object> env = RestFileSystemOptions.builder()
                 .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
@@ -124,7 +128,6 @@ public class CachingTest {
     public void offlineCacheTest() throws IOException, URISyntaxException {
         TestServer testServer = new TestServer();
         URI restRootURI = UriBuilder.fromUri(testServer.getServerURI()).scheme("ccs").build();
-        final Path tempDir = Files.createTempDirectory("rfs");
         RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         Map<String, Object> env = RestFileSystemOptions.builder()
                 .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
@@ -187,7 +190,6 @@ public class CachingTest {
      */
     @Test
     public void multiMountSharedCacheTest() throws URISyntaxException, IOException {
-        final Path tempDir = Files.createTempDirectory("rfs");
         RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
 
         TestServer testServer = new TestServer();
@@ -238,7 +240,6 @@ public class CachingTest {
      */
     @Test
     public void sameJvmCacheShareTest() throws URISyntaxException, IOException {
-        final Path tempDir = Files.createTempDirectory("rfs");
         RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
 
         Map<String, Object> env = RestFileSystemOptions.builder()

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CachingTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CachingTest.java
@@ -16,7 +16,9 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.UriBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
@@ -169,8 +171,13 @@ public class CachingTest {
         }
     }
 
+    /**
+     * Two different servers sharing one base cache location must both start:
+     * each gets its own per-server subdirectory (and JCS region), so there is no
+     * lock collision between distinct servers.
+     */
     @Test
-    public void cacheLockTest() throws URISyntaxException, IOException {
+    public void multiServerSharedBaseTest() throws URISyntaxException, IOException {
         final Path tempDir = Files.createTempDirectory("rfs");
 
         TestServer testServer = new TestServer();
@@ -182,29 +189,81 @@ public class CachingTest {
                     .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
                     .set(RestFileSystemOptions.CacheFallback.OFFLINE)
                     .build();
-            try (FileSystem restfs = FileSystems.newFileSystem(restRootURI, env)) {
+            URI restRootURI2 = UriBuilder.fromUri(testServer2.getServerURI()).scheme("ccs").build();
+            Map<String, Object> env2 = RestFileSystemOptions.builder()
+                    .cacheLocation(tempDir)
+                    .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
+                    .set(RestFileSystemOptions.CacheFallback.OFFLINE)
+                    .build();
+            try (FileSystem restfs = FileSystems.newFileSystem(restRootURI, env);
+                    FileSystem restfs2 = FileSystems.newFileSystem(restRootURI2, env2)) {
+                // Both file systems must have started, with distinct regions and disk dirs.
+                RestFileSystem client = (RestFileSystem) restfs;
+                RestFileSystem client2 = (RestFileSystem) restfs2;
+                Cache cache = client.getCache();
+                Cache cache2 = client2.getCache();
+                assertNotEquals(cache.getRegion(), cache2.getRegion());
+                assertNotEquals(cache.getDiskCacheLocation(), cache2.getDiskCacheLocation());
+                assertTrue(Files.isDirectory(cache.getDiskCacheLocation()));
+                assertTrue(Files.isDirectory(cache2.getDiskCacheLocation()));
 
-                URI restRootURI2 = UriBuilder.fromUri(testServer2.getServerURI()).scheme("ccs").build();
-                Map<String, Object> env2 = RestFileSystemOptions.builder()
-                        .cacheLocation(tempDir)
-                        .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
-                        .set(RestFileSystemOptions.CacheFallback.OFFLINE)
-                        .build();
-                try {
-                    FileSystems.newFileSystem(restRootURI2, env2);
-                    fail();
-                } catch (IOException x) {
-                    assertTrue(x.getMessage().contains("in use"));
+                // Write and read a file through the first server, populating its cache.
+                final String content = "cached on server one";
+                final String fileName = "isolated.txt";
+                Path pathInServer1 = restfs.getPath(fileName);
+                try (BufferedWriter writer = Files.newBufferedWriter(pathInServer1)) {
+                    writer.append(content);
                 }
+                listAndRead(pathInServer1, content, 1);
 
-                env2.put(RestFileSystemOptions.ALLOW_ALTERNATE_CACHE_LOCATION, true);
-                try (FileSystem restfs2 = FileSystems.newFileSystem(restRootURI2, env2)) {
-                    // We should get here
-                }
+                // The entry lives in server one's cache but not in server two's.
+                URI fileUri = new URI(client.getURI("rest/download/" + fileName).toString().replace("ccs:", "http:"));
+                assertNotNull(cache.getEntry(fileUri));
+                assertNull(cache2.getEntry(fileUri));
             }
         } finally {
             testServer.shutdown();
             testServer2.shutdown();
+        }
+    }
+
+    /**
+     * Genuine contention on a single server's cache directory must still be
+     * rejected: a second cache for the same server URI and base location cannot
+     * take the disk lock, and {@code ALLOW_ALTERNATE_CACHE_LOCATION} lets it fall
+     * back to a sibling directory.
+     */
+    @Test
+    public void cacheLockTest() throws URISyntaxException, IOException {
+        final Path tempDir = Files.createTempDirectory("rfs");
+        final URI serverURI = new URI("ccs://localhost:9999/RestFileServer/");
+
+        Map<String, Object> env = RestFileSystemOptions.builder()
+                .cacheLocation(tempDir)
+                .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
+                .set(RestFileSystemOptions.CacheFallback.OFFLINE)
+                .build();
+        Cache cache = new Cache(new RestFileSystemOptionsHelper(env), serverURI);
+        try {
+            try {
+                new Cache(new RestFileSystemOptionsHelper(env), serverURI);
+                fail();
+            } catch (IOException x) {
+                assertTrue(x.getMessage().contains("in use"));
+            }
+
+            Map<String, Object> env2 = RestFileSystemOptions.builder()
+                    .cacheLocation(tempDir)
+                    .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
+                    .set(RestFileSystemOptions.CacheFallback.OFFLINE)
+                    .ignoreLockedCache(true)
+                    .build();
+            Cache cache2 = new Cache(new RestFileSystemOptionsHelper(env2), serverURI);
+            // The alternate location must differ from the primary one.
+            assertNotEquals(cache.getDiskCacheLocation(), cache2.getDiskCacheLocation());
+            cache2.close();
+        } finally {
+            cache.close();
         }
     }
 

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CachingTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/CachingTest.java
@@ -16,11 +16,10 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.UriBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 import org.lsst.ccs.rest.file.server.client.implementation.Cache.CacheEntry;
@@ -31,6 +30,15 @@ import org.lsst.ccs.web.rest.file.server.TestServer;
  * @author tonyj
  */
 public class CachingTest {
+
+    /**
+     * The cache location is JVM-global (ADR 0003). Tests point it at a temp dir
+     * via the backdoor and reset it here so state does not leak between tests.
+     */
+    @AfterEach
+    public void resetGlobalCacheConfig() {
+        RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
+    }
 
     @Test
     public void cacheTest()  throws URISyntaxException, IOException, InterruptedException {
@@ -46,8 +54,8 @@ public class CachingTest {
         TestServer testServer = new TestServer(port);
         URI restRootURI = UriBuilder.fromUri(testServer.getServerURI()).scheme("ccs").build();
         final Path tempDir = Files.createTempDirectory("rfs");
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         Map<String, Object> env = RestFileSystemOptions.builder()
-                .cacheLocation(tempDir)
                 .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
                 .set(cacheMode)
                 .build();
@@ -65,17 +73,17 @@ public class CachingTest {
             Cache cache = client.getCache();
             URI tmpFileUri = client.getURI("rest/download/"+fileName);
             URI fileUri = new URI(tmpFileUri.toString().replace("ccs:", "http:"));
-            
+
             listAndRead(pathInRestServer, content, 1);
             CacheEntry e = cache.getEntry(fileUri);
             assertNotNull(e);
             assertEquals(0, e.getUpdateCount());
-            
+
             // Read again, this time should use the cache
             listAndRead(pathInRestServer, content, 1);
             // Wen using WHEN_POSSIBLE, cache is never updated
             assertEquals(cacheMode == RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE ? 0 : 1, e.getUpdateCount());
-            
+
             // Change the file, and make sure things still work as expected
             // Note, the file cache uses "lastModified" timestamps, which are only accurate to 1 second
             // so need to pause to make sure new file has a different timestamp
@@ -94,7 +102,7 @@ public class CachingTest {
             // Read again, this time should use the cache
             listAndRead(pathInRestServer, expectedContents, 1);
             assertEquals(cacheMode == RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE ? 0 : 1, e.getUpdateCount());
-            
+
             Path pathInRestServer2 = restfs.getPath(fileName + "2");
             // Create a new file, and make sure the directory listing shows it
             try (BufferedWriter writer = Files.newBufferedWriter(pathInRestServer2)) {
@@ -105,7 +113,7 @@ public class CachingTest {
             listAndRead(pathInRestServer, expectedContents, expectedDirectorySize);
             // In this case cache entry will not have changed, so no need to refetch it.
             assertEquals(cacheMode == RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE ? 0 : 2, e.getUpdateCount());
-            
+
             // Read again, this time should use the cache
             listAndRead(pathInRestServer, expectedContents, expectedDirectorySize);
             assertEquals(cacheMode == RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE ? 0 : 3, e.getUpdateCount());
@@ -117,8 +125,8 @@ public class CachingTest {
         TestServer testServer = new TestServer();
         URI restRootURI = UriBuilder.fromUri(testServer.getServerURI()).scheme("ccs").build();
         final Path tempDir = Files.createTempDirectory("rfs");
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         Map<String, Object> env = RestFileSystemOptions.builder()
-                .cacheLocation(tempDir)
                 .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
                 .set(RestFileSystemOptions.CacheFallback.OFFLINE)
                 .build();
@@ -172,54 +180,48 @@ public class CachingTest {
     }
 
     /**
-     * Two different servers sharing one base cache location must both start:
-     * each gets its own per-server subdirectory (and JCS region), so there is no
-     * lock collision between distinct servers.
+     * Two different servers in one JVM share the single per-JVM cache: each
+     * resolves the same disk directory, and an entry cached through one mount is
+     * visible through the other (they back onto the same JCS region). This
+     * inverts ADR 0001's isolation assertion.
      */
     @Test
-    public void multiServerSharedBaseTest() throws URISyntaxException, IOException {
+    public void multiMountSharedCacheTest() throws URISyntaxException, IOException {
         final Path tempDir = Files.createTempDirectory("rfs");
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
 
         TestServer testServer = new TestServer();
         TestServer testServer2 = new TestServer(9998);
         try {
             URI restRootURI = UriBuilder.fromUri(testServer.getServerURI()).scheme("ccs").build();
-            Map<String, Object> env = RestFileSystemOptions.builder()
-                    .cacheLocation(tempDir)
-                    .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
-                    .set(RestFileSystemOptions.CacheFallback.OFFLINE)
-                    .build();
             URI restRootURI2 = UriBuilder.fromUri(testServer2.getServerURI()).scheme("ccs").build();
-            Map<String, Object> env2 = RestFileSystemOptions.builder()
-                    .cacheLocation(tempDir)
+            Map<String, Object> env = RestFileSystemOptions.builder()
                     .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
                     .set(RestFileSystemOptions.CacheFallback.OFFLINE)
                     .build();
             try (FileSystem restfs = FileSystems.newFileSystem(restRootURI, env);
-                    FileSystem restfs2 = FileSystems.newFileSystem(restRootURI2, env2)) {
-                // Both file systems must have started, with distinct regions and disk dirs.
+                    FileSystem restfs2 = FileSystems.newFileSystem(restRootURI2, env)) {
                 RestFileSystem client = (RestFileSystem) restfs;
                 RestFileSystem client2 = (RestFileSystem) restfs2;
                 Cache cache = client.getCache();
                 Cache cache2 = client2.getCache();
-                assertNotEquals(cache.getRegion(), cache2.getRegion());
-                assertNotEquals(cache.getDiskCacheLocation(), cache2.getDiskCacheLocation());
+                // Both mounts share the one per-JVM cache directory.
+                assertEquals(cache.getDiskCacheLocation(), cache2.getDiskCacheLocation());
                 assertTrue(Files.isDirectory(cache.getDiskCacheLocation()));
-                assertTrue(Files.isDirectory(cache2.getDiskCacheLocation()));
 
-                // Write and read a file through the first server, populating its cache.
+                // Write and read a file through the first server, populating the cache.
                 final String content = "cached on server one";
-                final String fileName = "isolated.txt";
+                final String fileName = "shared.txt";
                 Path pathInServer1 = restfs.getPath(fileName);
                 try (BufferedWriter writer = Files.newBufferedWriter(pathInServer1)) {
                     writer.append(content);
                 }
                 listAndRead(pathInServer1, content, 1);
 
-                // The entry lives in server one's cache but not in server two's.
+                // The entry is visible through both caches: they share one JCS region.
                 URI fileUri = new URI(client.getURI("rest/download/" + fileName).toString().replace("ccs:", "http:"));
                 assertNotNull(cache.getEntry(fileUri));
-                assertNull(cache2.getEntry(fileUri));
+                assertNotNull(cache2.getEntry(fileUri));
             }
         } finally {
             testServer.shutdown();
@@ -228,39 +230,26 @@ public class CachingTest {
     }
 
     /**
-     * Genuine contention on a single server's cache directory must still be
-     * rejected: a second cache for the same server URI and base location cannot
-     * take the disk lock, and {@code ALLOW_ALTERNATE_CACHE_LOCATION} lets it fall
-     * back to a sibling directory.
+     * Two caches for the same location in one JVM must both succeed: the second
+     * gets an {@code OverlappingFileLockException}, recognises the location is
+     * already held by this JVM, and shares it (no lock, same directory). Genuine
+     * cross-process contention (a foreign {@code tryLock()} returning null) is
+     * covered by {@link CacheLockCrossJvmTest}.
      */
     @Test
-    public void cacheLockTest() throws URISyntaxException, IOException {
+    public void sameJvmCacheShareTest() throws URISyntaxException, IOException {
         final Path tempDir = Files.createTempDirectory("rfs");
-        final URI serverURI = new URI("ccs://localhost:9999/RestFileServer/");
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
 
         Map<String, Object> env = RestFileSystemOptions.builder()
-                .cacheLocation(tempDir)
                 .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
                 .set(RestFileSystemOptions.CacheFallback.OFFLINE)
                 .build();
-        Cache cache = new Cache(new RestFileSystemOptionsHelper(env), serverURI);
+        Cache cache = new Cache(new RestFileSystemOptionsHelper(env));
         try {
-            try {
-                new Cache(new RestFileSystemOptionsHelper(env), serverURI);
-                fail();
-            } catch (IOException x) {
-                assertTrue(x.getMessage().contains("in use"));
-            }
-
-            Map<String, Object> env2 = RestFileSystemOptions.builder()
-                    .cacheLocation(tempDir)
-                    .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
-                    .set(RestFileSystemOptions.CacheFallback.OFFLINE)
-                    .ignoreLockedCache(true)
-                    .build();
-            Cache cache2 = new Cache(new RestFileSystemOptionsHelper(env2), serverURI);
-            // The alternate location must differ from the primary one.
-            assertNotEquals(cache.getDiskCacheLocation(), cache2.getDiskCacheLocation());
+            Cache cache2 = new Cache(new RestFileSystemOptionsHelper(env));
+            // The second cache shares the first's location rather than failing.
+            assertEquals(cache.getDiskCacheLocation(), cache2.getDiskCacheLocation());
             cache2.close();
         } finally {
             cache.close();

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/DefaultEnvTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/DefaultEnvTest.java
@@ -3,10 +3,12 @@ package org.lsst.ccs.rest.file.server.client.implementation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 
@@ -48,6 +50,70 @@ public class DefaultEnvTest {
         
         
         System.setProperty("org.lsst.ccs.rest.file.client.defaultEnvironment", "");
-        
+
+    }
+
+    /**
+     * Clears both static default sources so cascade tests don't leak into each
+     * other or into the rest of the suite.
+     */
+    @AfterEach
+    public void clearDefaults() {
+        System.clearProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY);
+        RestFileSystemProvider.setDefaultFileSystemOption(null);
+    }
+
+    /**
+     * A key in the explicit env overrides the same key from the system-property
+     * default, while keys absent from the explicit env still fall through to it.
+     */
+    @Test
+    public void explicitOverridesPropertyPerKey() {
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY,
+                "{\"CacheOptions\":\"MEMORY_AND_DISK\",\"CacheFallback\":\"OFFLINE\"}");
+
+        Map<String, Object> env = new HashMap<>();
+        env.put(RestFileSystemOptions.CACHE_FALLBACK, RestFileSystemOptions.CacheFallback.ALWAYS);
+
+        RestFileSystemOptionsHelper helper = new RestFileSystemOptionsHelper(env);
+        // Overridden by the explicit env.
+        assertEquals(RestFileSystemOptions.CacheFallback.ALWAYS, helper.getCacheFallback());
+        // Fell through from the system property.
+        assertEquals(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK, helper.getCacheOptions());
+    }
+
+    /**
+     * Precedence is explicit env, then programmatic default, then system
+     * property, then the hardcoded fallback.
+     */
+    @Test
+    public void cascadePrecedence() {
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY,
+                "{\"CacheOptions\":\"MEMORY_ONLY\",\"CacheFallback\":\"NEVER\"}");
+        Map<String, Object> programmatic = new HashMap<>();
+        programmatic.put(RestFileSystemOptions.CACHE_OPTIONS, RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK);
+        RestFileSystemProvider.setDefaultFileSystemOption(programmatic);
+
+        Map<String, Object> env = new HashMap<>();
+        env.put(RestFileSystemOptions.CACHE_FALLBACK, RestFileSystemOptions.CacheFallback.ALWAYS);
+
+        RestFileSystemOptionsHelper helper = new RestFileSystemOptionsHelper(env);
+        // Explicit env wins.
+        assertEquals(RestFileSystemOptions.CacheFallback.ALWAYS, helper.getCacheFallback());
+        // Programmatic default beats the system property.
+        assertEquals(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK, helper.getCacheOptions());
+        // Nothing set this anywhere but the hardcoded fallback.
+        assertEquals(RestFileSystemOptions.SSLOptions.AUTO, helper.isUseSSL());
+    }
+
+    /**
+     * With no explicit env, no programmatic default, and no system property,
+     * the hardcoded fallbacks apply.
+     */
+    @Test
+    public void hardcodedFallbackWhenNothingConfigured() {
+        RestFileSystemOptionsHelper helper = new RestFileSystemOptionsHelper(null);
+        assertEquals(RestFileSystemOptions.CacheOptions.NONE, helper.getCacheOptions());
+        assertEquals(RestFileSystemOptions.CacheFallback.OFFLINE, helper.getCacheFallback());
     }
 }

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/DefaultEnvTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/DefaultEnvTest.java
@@ -33,10 +33,11 @@ public class DefaultEnvTest {
         RestFileSystemOptionsHelper restFileSystemOptionsHelper = new RestFileSystemOptionsHelper(null);
         assertEquals(RestFileSystemOptions.SSLOptions.AUTO, restFileSystemOptionsHelper.isUseSSL());
         assertEquals(RestFileSystemOptions.CacheFallback.OFFLINE, restFileSystemOptionsHelper.getCacheFallback());
-        assertTrue(restFileSystemOptionsHelper.allowAlternateCacheLoction());
-        assertEquals("/tmp", restFileSystemOptionsHelper.getDiskCacheLocation().toAbsolutePath().toString());
+        // CacheLocation and the spill flag are now resolved globally (ADR 0003).
+        assertTrue(RestFileSystemOptionsHelper.allowAlternateCacheLocation());
+        assertEquals("/tmp", RestFileSystemOptionsHelper.getGlobalCacheLocation().toAbsolutePath().toString());
     }
-    
+
     @Test
     public void defaultEnvTest1() {
         String jsonEnv = " {\"CacheOptions\":\"MEMORY_AND_DISK\",\"CacheLocation\":\"~/ccs/cache/remoteFileSystem\"}";
@@ -47,41 +48,40 @@ public class DefaultEnvTest {
         assertEquals(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK, optionsHelper.getCacheOptions());
         // The leading ~ is expanded to the user's home directory.
         assertEquals(System.getProperty("user.home") + "/ccs/cache/remoteFileSystem",
-                optionsHelper.getDiskCacheLocation().toString());
-
-
-
-        System.setProperty("org.lsst.ccs.rest.file.client.defaultEnvironment", "");
-
+                RestFileSystemOptionsHelper.getGlobalCacheLocation().toString());
     }
 
     /**
      * A bare {@code ~} expands to the user's home directory; a path with no
-     * leading tilde is left untouched (aside from lexical normalization).
+     * leading tilde is left untouched (aside from lexical normalization). The
+     * global location is resolved once per JVM, so we reset between cases.
      */
     @Test
     public void tildeExpansion() {
         String home = System.getProperty("user.home");
 
         System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY, "{\"CacheLocation\":\"~\"}");
-        assertEquals(home, new RestFileSystemOptionsHelper(null).getDiskCacheLocation().toString());
+        assertEquals(home, RestFileSystemOptionsHelper.getGlobalCacheLocation().toString());
 
+        RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
         System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY, "{\"CacheLocation\":\"/var/lib/ccs/rest-cache\"}");
-        assertEquals("/var/lib/ccs/rest-cache", new RestFileSystemOptionsHelper(null).getDiskCacheLocation().toString());
+        assertEquals("/var/lib/ccs/rest-cache", RestFileSystemOptionsHelper.getGlobalCacheLocation().toString());
 
         // ../ and ./ are collapsed lexically by normalize().
+        RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
         System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY, "{\"CacheLocation\":\"/var/lib/ccs/../ccs/rest-cache\"}");
-        assertEquals("/var/lib/ccs/rest-cache", new RestFileSystemOptionsHelper(null).getDiskCacheLocation().toString());
+        assertEquals("/var/lib/ccs/rest-cache", RestFileSystemOptionsHelper.getGlobalCacheLocation().toString());
     }
 
     /**
-     * Clears both static default sources so cascade tests don't leak into each
+     * Clears the static default sources so cascade tests don't leak into each
      * other or into the rest of the suite.
      */
     @AfterEach
     public void clearDefaults() {
         System.clearProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY);
         RestFileSystemProvider.setDefaultFileSystemOption(null);
+        RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
     }
 
     /**
@@ -136,5 +136,63 @@ public class DefaultEnvTest {
         RestFileSystemOptionsHelper helper = new RestFileSystemOptionsHelper(null);
         assertEquals(RestFileSystemOptions.CacheOptions.NONE, helper.getCacheOptions());
         assertEquals(RestFileSystemOptions.CacheFallback.OFFLINE, helper.getCacheFallback());
+    }
+
+    /**
+     * The cache location is JVM-global (ADR 0003): a per-file-system
+     * {@code CacheLocation} in the env is ignored, so the toolkit's per-mount
+     * call is inert. Only the global property (or built-in default) is honored.
+     */
+    @Test
+    public void perFsCacheLocationIsIgnored() {
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY,
+                "{\"CacheLocation\":\"/var/lib/ccs/global-cache\"}");
+        Map<String, Object> env = new HashMap<>();
+        env.put(RestFileSystemOptions.CACHE_LOCATION, new File("/tmp/per-fs-should-be-ignored"));
+        // Construct a helper with the per-FS value present; it must not affect the global location.
+        new RestFileSystemOptionsHelper(env);
+        assertEquals("/var/lib/ccs/global-cache",
+                RestFileSystemOptionsHelper.getGlobalCacheLocation().toString());
+    }
+
+    /**
+     * With no property and no backdoor, the global location is the built-in
+     * default under the user's home.
+     */
+    @Test
+    public void builtInDefaultCacheLocation() {
+        assertEquals(System.getProperty("user.home") + "/ccs/cache/default",
+                RestFileSystemOptionsHelper.getGlobalCacheLocation().toString());
+    }
+
+    /**
+     * A programmatic location override (the CLI's {@code --cacheDir}) wins over
+     * the property, and the spill flag still resolves from the property.
+     */
+    @Test
+    public void cacheLocationOverrideWinsBeforeConfigured() {
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY,
+                "{\"CacheLocation\":\"/var/lib/ccs/from-property\",\"CacheFallbackLocation\":true}");
+        RestFileSystemOptionsHelper.setCacheLocationOverride(java.nio.file.Paths.get("/tmp/from-cli"));
+
+        assertEquals("/tmp/from-cli", RestFileSystemOptionsHelper.getGlobalCacheLocation().toString());
+        // Spill flag still comes from the property, not reset by the override.
+        assertTrue(RestFileSystemOptionsHelper.allowAlternateCacheLocation());
+    }
+
+    /**
+     * Once the cache is configured (location resolved), a later override attempt
+     * fails rather than silently having no effect.
+     */
+    @Test
+    public void cacheLocationOverrideRejectedAfterConfigured() {
+        // Resolve the location, marking the cache configured.
+        RestFileSystemOptionsHelper.getGlobalCacheLocation();
+        try {
+            RestFileSystemOptionsHelper.setCacheLocationOverride(java.nio.file.Paths.get("/tmp/too-late"));
+            org.junit.jupiter.api.Assertions.fail("expected IllegalStateException");
+        } catch (IllegalStateException x) {
+            assertTrue(x.getMessage().contains("already configured"), x.getMessage());
+        }
     }
 }

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/DefaultEnvTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/DefaultEnvTest.java
@@ -41,16 +41,37 @@ public class DefaultEnvTest {
     public void defaultEnvTest1() {
         String jsonEnv = " {\"CacheOptions\":\"MEMORY_AND_DISK\",\"CacheLocation\":\"~/ccs/cache/remoteFileSystem\"}";
         System.setProperty("org.lsst.ccs.rest.file.client.defaultEnvironment", jsonEnv);
-        
+
         RestFileSystemOptionsHelper optionsHelper = new RestFileSystemOptionsHelper(null);
-        
+
         assertEquals(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK, optionsHelper.getCacheOptions());
-        assertEquals(optionsHelper.getDiskCacheLocation().toString(),"~/ccs/cache/remoteFileSystem");
-        
-        
-        
+        // The leading ~ is expanded to the user's home directory.
+        assertEquals(System.getProperty("user.home") + "/ccs/cache/remoteFileSystem",
+                optionsHelper.getDiskCacheLocation().toString());
+
+
+
         System.setProperty("org.lsst.ccs.rest.file.client.defaultEnvironment", "");
 
+    }
+
+    /**
+     * A bare {@code ~} expands to the user's home directory; a path with no
+     * leading tilde is left untouched (aside from lexical normalization).
+     */
+    @Test
+    public void tildeExpansion() {
+        String home = System.getProperty("user.home");
+
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY, "{\"CacheLocation\":\"~\"}");
+        assertEquals(home, new RestFileSystemOptionsHelper(null).getDiskCacheLocation().toString());
+
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY, "{\"CacheLocation\":\"/var/lib/ccs/rest-cache\"}");
+        assertEquals("/var/lib/ccs/rest-cache", new RestFileSystemOptionsHelper(null).getDiskCacheLocation().toString());
+
+        // ../ and ./ are collapsed lexically by normalize().
+        System.setProperty(RestFileSystemOptions.DEFAULT_ENV_PROPERTY, "{\"CacheLocation\":\"/var/lib/ccs/../ccs/rest-cache\"}");
+        assertEquals("/var/lib/ccs/rest-cache", new RestFileSystemOptionsHelper(null).getDiskCacheLocation().toString());
     }
 
     /**

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/SpeedTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/SpeedTest.java
@@ -21,9 +21,10 @@ public class SpeedTest {
     @Test
     public void testSpeed() throws IOException {
         final Path tempDir = Files.createTempDirectory("rfs");
+        // Cache location is JVM-global now (ADR 0003); set it via the test backdoor.
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         URI uri = URI.create("ccs://lsst-camera-dev.slac.stanford.edu/RestFileServer/");
         Map<String, Object> env = RestFileSystemOptions.builder()
-                .cacheLocation(tempDir)
                 .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
                 .set(RestFileSystemOptions.CacheFallback.OFFLINE)
                 .build();
@@ -35,7 +36,7 @@ public class SpeedTest {
         long time2 = readFile(pathInRestServer);
         Assert.assertTrue(time2<time1);
 
-        ((RestFileSystem)restfs).getCache().setCacheFallbackOption(RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE);
+        ((RestFileSystem)restfs).setCacheFallbackOption(RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE);
         // Now it should come from cache without trips to the remote server
         long time3 = readFile(pathInRestServer);
         Assert.assertTrue(time3<=time2);
@@ -49,7 +50,7 @@ public class SpeedTest {
         long time5 = readFile(pathInRestServer2);
         Assert.assertTrue(time5<time4);
 
-        ((RestFileSystem)restfs).getCache().setCacheFallbackOption(RestFileSystemOptions.CacheFallback.OFFLINE);
+        ((RestFileSystem)restfs).setCacheFallbackOption(RestFileSystemOptions.CacheFallback.OFFLINE);
         // This time it should still come from the cache, but with round trips to the server,
         // so it should be slower than the previous result.
         long time6 = readFile(pathInRestServer2);

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/SpeedTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/SpeedTest.java
@@ -8,8 +8,10 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 
 /**
@@ -18,9 +20,18 @@ import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
  */
 public class SpeedTest {
 
+    /** JUnit creates this per test and deletes the tree afterwards, so the cache dir does not leak. */
+    @TempDir
+    Path tempDir;
+
+    /** Reset the JVM-global cache location set via the backdoor (ADR 0003). */
+    @AfterEach
+    public void resetGlobalCacheConfig() {
+        RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
+    }
+
     @Test
     public void testSpeed() throws IOException {
-        final Path tempDir = Files.createTempDirectory("rfs");
         // Cache location is JVM-global now (ADR 0003); set it via the test backdoor.
         RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         URI uri = URI.create("ccs://lsst-camera-dev.slac.stanford.edu/RestFileServer/");
@@ -34,21 +45,21 @@ public class SpeedTest {
         long time1 = readFile(pathInRestServer);
         // Second time should come from cache
         long time2 = readFile(pathInRestServer);
-        Assert.assertTrue(time2<time1);
+        assertTrue(time2<time1);
 
         ((RestFileSystem)restfs).setCacheFallbackOption(RestFileSystemOptions.CacheFallback.WHEN_POSSIBLE);
         // Now it should come from cache without trips to the remote server
         long time3 = readFile(pathInRestServer);
-        Assert.assertTrue(time3<=time2);
+        assertTrue(time3<=time2);
 
         Path pathInRestServer2 = restfs.getPath("dictionaries/command/FocalPlane/846244239.ser");
         long time4 = readFile(pathInRestServer2);
         //The second file is smaller, so it should take less than the first file
-        Assert.assertTrue(time4<time1);
+        assertTrue(time4<time1);
         
         // Now it should come from cache without trips to the remote server
         long time5 = readFile(pathInRestServer2);
-        Assert.assertTrue(time5<time4);
+        assertTrue(time5<time4);
 
         ((RestFileSystem)restfs).setCacheFallbackOption(RestFileSystemOptions.CacheFallback.OFFLINE);
         // This time it should still come from the cache, but with round trips to the server,
@@ -56,8 +67,8 @@ public class SpeedTest {
         long time6 = readFile(pathInRestServer2);
         //Since there are trip to the server, this time should be longer than
         //the previous with trips.
-        Assert.assertTrue(time5<=time6);
-//        Assert.assertTrue(time6>time4);
+        assertTrue(time5<=time6);
+//        assertTrue(time6>time4);
         restfs.close();
 
         

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/VersionedFileTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/VersionedFileTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.lsst.ccs.rest.file.server.client.RestFileSystemOptions;
 import org.lsst.ccs.rest.file.server.client.VersionOpenOption;
 import org.lsst.ccs.rest.file.server.client.VersionedFileAttributes;
@@ -30,6 +31,10 @@ import org.lsst.ccs.web.rest.file.server.TestServer;
  * 
  */
 public class VersionedFileTest {
+
+    /** JUnit creates this per test and deletes the tree afterwards, so the cache dir does not leak. */
+    @TempDir
+    Path tempDir;
 
     /** Reset the JVM-global cache location set via the backdoor (ADR 0003). */
     @org.junit.jupiter.api.AfterEach
@@ -94,7 +99,6 @@ public class VersionedFileTest {
     public void cacheTest(int port, RestFileSystemOptions.CacheFallback cacheMode) throws URISyntaxException, IOException, InterruptedException {
         TestServer testServer = new TestServer(port);
         URI restRootURI = UriBuilder.fromUri(testServer.getServerURI()).scheme("ccs").build();
-        final Path tempDir = Files.createTempDirectory("rfs");
         // Cache location is JVM-global now (ADR 0003); set it via the test backdoor.
         RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         Map<String, Object> env = RestFileSystemOptions.builder()

--- a/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/VersionedFileTest.java
+++ b/client/src/test/java/org/lsst/ccs/rest/file/server/client/implementation/VersionedFileTest.java
@@ -31,7 +31,12 @@ import org.lsst.ccs.web.rest.file.server.TestServer;
  */
 public class VersionedFileTest {
 
-    
+    /** Reset the JVM-global cache location set via the backdoor (ADR 0003). */
+    @org.junit.jupiter.api.AfterEach
+    public void resetGlobalCacheConfig() {
+        RestFileSystemOptionsHelper.resetGlobalCacheConfigForTest();
+    }
+
     @Test
     public void fileWithVersionTest() throws IOException {
         RestPath path = new RestPath(null, "/file(7).txt");
@@ -90,8 +95,9 @@ public class VersionedFileTest {
         TestServer testServer = new TestServer(port);
         URI restRootURI = UriBuilder.fromUri(testServer.getServerURI()).scheme("ccs").build();
         final Path tempDir = Files.createTempDirectory("rfs");
+        // Cache location is JVM-global now (ADR 0003); set it via the test backdoor.
+        RestFileSystemOptionsHelper.setGlobalCacheConfigForTest(tempDir, false);
         Map<String, Object> env = RestFileSystemOptions.builder()
-                .cacheLocation(tempDir)
                 .set(RestFileSystemOptions.CacheOptions.MEMORY_AND_DISK)
                 .set(cacheMode)
                 .build();

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,12 +13,13 @@ Organized by lifecycle — each category has its own maintenance rule.
 
 **Decisions**
 - [0001 — Per-file-system cache isolation](decisions/0001-per-file-system-cache-isolation.md) — largely superseded by 0003
-- [0002 — Option resolution cascade](decisions/0002-option-resolution-cascade.md)
+- [0002 — Option resolution cascade](decisions/0002-option-resolution-cascade.md) — amended by 0003 (two keys go global)
 - [0003 — One shared cache per JVM](decisions/0003-shared-per-jvm-cache.md) — proposed
 
 **Guides**
 - [Toolkit cache compatibility](guides/toolkit-cache-compatibility.md)
 
 **Workplans**
-- [LSSTCCS-3029 — Per-file-system cache isolation](workplans/LSSTCCS-3029-per-file-system-cache-isolation.md)
+- [LSSTCCS-3029 — One shared cache per JVM](workplans/LSSTCCS-3029-shared-per-jvm-cache.md) — active (ADR 0003)
+- [LSSTCCS-3029 — Per-file-system cache isolation](workplans/LSSTCCS-3029-per-file-system-cache-isolation.md) — superseded (ADR 0001)
 - [HANDOFF — current state + backlog](workplans/HANDOFF.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Organized by lifecycle — each category has its own maintenance rule.
 **Decisions**
 - [0001 — Per-file-system cache isolation](decisions/0001-per-file-system-cache-isolation.md) — largely superseded by 0003
 - [0002 — Option resolution cascade](decisions/0002-option-resolution-cascade.md) — amended by 0003 (two keys go global)
-- [0003 — One shared cache per JVM](decisions/0003-shared-per-jvm-cache.md) — proposed
+- [0003 — One shared cache per JVM](decisions/0003-shared-per-jvm-cache.md) — accepted
 
 **Guides**
 - [Toolkit cache compatibility](guides/toolkit-cache-compatibility.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Documentation
+
+Organized by lifecycle — each category has its own maintenance rule.
+
+| Category | Holds | Lifecycle |
+|----------|-------|-----------|
+| [decisions/](decisions/) | ADRs — the *why* | Long-lived, append-only. Reverse a decision with a new superseding ADR; don't rewrite the old one. |
+| [guides/](guides/) | How the system behaves / how to use it | Living. Updated in the same PR that changes the behavior. |
+| [workplans/](workplans/) | How we'll build a ticket's work | Disposable scaffolding, kept in-repo. |
+| [workplans/HANDOFF.md](workplans/HANDOFF.md) | Where the last session stopped + backlog | Volatile. Refreshed when wrapping up. |
+
+## Contents
+
+**Decisions**
+- [0001 — Per-file-system cache isolation](decisions/0001-per-file-system-cache-isolation.md) — largely superseded by 0003
+- [0002 — Option resolution cascade](decisions/0002-option-resolution-cascade.md)
+- [0003 — One shared cache per JVM](decisions/0003-shared-per-jvm-cache.md) — proposed
+
+**Guides**
+- [Toolkit cache compatibility](guides/toolkit-cache-compatibility.md)
+
+**Workplans**
+- [LSSTCCS-3029 — Per-file-system cache isolation](workplans/LSSTCCS-3029-per-file-system-cache-isolation.md)
+- [HANDOFF — current state + backlog](workplans/HANDOFF.md)

--- a/docs/decisions/0001-per-file-system-cache-isolation.md
+++ b/docs/decisions/0001-per-file-system-cache-isolation.md
@@ -1,6 +1,6 @@
 # 0001 — Per-file-system cache isolation
 
-- Status: accepted
+- Status: largely superseded by [0003](0003-shared-per-jvm-cache.md)
 - Date: 2026-07-20
 - Ticket: LSSTCCS-3029
 

--- a/docs/decisions/0001-per-file-system-cache-isolation.md
+++ b/docs/decisions/0001-per-file-system-cache-isolation.md
@@ -1,0 +1,69 @@
+# 0001 — Per-file-system cache isolation
+
+- Status: accepted
+- Date: 2026-07-20
+- Ticket: LSSTCCS-3029
+
+## Context
+
+The CCS bootstrap adds several `ccs://` remote file systems at JVM start, before the
+toolkit's configuration layer is available. We want those mounts to default to
+`MEMORY_AND_DISK` caching. The current cache implementation was written as if there is
+one file system per JVM, so making several mounts use a disk cache fails.
+
+Two layers share state across file systems, and both break under multiple mounts:
+
+1. **Disk path + file lock.** `CACHE_LOCATION` is used as the literal leaf directory
+   that gets locked (`Cache.java`) and written into JCS `DiskPath`. Two `MEMORY_AND_DISK`
+   file systems pointed at the same location — the second throws `"Cache already in use"`
+   (asserted today by `cacheLockTest` in `CachingTest`).
+2. **JCS region (JVM-global singleton).** Every `Cache` calls
+   `CompositeCacheManager.getUnconfiguredInstance()` and `JCS.getInstance("default")`
+   with the region name hardcoded to `"default"` and the disk auxiliary hardcoded to
+   `"DC"`. Even with distinct directories, all file systems collapse onto one shared
+   region, one disk store, and one `MaxObjects=1000` budget; the last `ccm.configure(props)`
+   wins.
+
+The existing `ALLOW_ALTERNATE_CACHE_LOCATION` fallback (spilling to `<dir>-1`, `-2`
+siblings) is not a solution: it only addresses layer 1, still shares the `"default"`
+region (layer 2), and assigns suffixes by construction order — so a server does not
+reliably reattach to its own cache after a restart.
+
+## Decision
+
+Give each remote file system its own JCS region *and* its own disk directory, auto-derived
+from a stable per-server key computed from `RestFileSystem.getFullURI()` (server URI +
+mount point).
+
+- The key is sanitized to a filesystem- and JCS-safe token and made deterministic across
+  restarts (sanitized host/port/path plus a short stable hash of the full URI), so a
+  server reattaches to its own on-disk cache.
+- `CACHE_LOCATION` is reinterpreted as a **base** directory; each file system uses
+  `<base>/<key>` as its disk directory. The per-directory lock keeps its real purpose:
+  guarding against a *different process* reusing the same cache.
+- The JCS `CompositeCacheManager` remains a singleton, but hosts N independent regions —
+  one per server — each with its own disk auxiliary and `DiskPath`. The `memory.ccf` /
+  `disk.ccf` resources become templates whose region/auxiliary/disk-path tokens are
+  substituted per instance.
+
+The bootstrap then needs only a single default policy (one base `CACHE_LOCATION`, or none)
+and every mount fans out to its own cache with no per-mount configuration.
+
+## Consequences
+
+- The premise of `cacheLockTest` is intentionally reversed: two servers sharing a base
+  `CACHE_LOCATION` now both succeed. That test is rewritten to assert isolation, plus a
+  case proving the lock still fires for genuine same-directory contention.
+- `CACHE_LOCATION` changes meaning (leaf → base directory). Callers are internal, but any
+  deployed config relying on the old leaf semantics must be reviewed.
+- Repeated `ccm.configure(props)` on the singleton must accumulate regions rather than
+  reset existing ones. If it turns out to be destructive, the implementation switches to
+  programmatic region creation (`ccm.getCache(region, attrs)` plus a manually attached
+  disk auxiliary). This is the main technical risk and is covered by a test.
+
+## Out of scope
+
+Making `MEMORY_AND_DISK` the *default* policy at bootstrap, and the related wiring gap
+where a non-null empty `NO_ENV` map shadows the `DEFAULT_ENV_PROPERTY` system property in
+`RestFileSystemProvider.newFileSystem`, are separate concerns tracked in HANDOFF. This ADR
+covers only the isolation mechanism that must exist before that default is safe.

--- a/docs/decisions/0002-option-resolution-cascade.md
+++ b/docs/decisions/0002-option-resolution-cascade.md
@@ -1,8 +1,15 @@
 # 0002 — Option resolution cascade for the ccs:// client
 
-- Status: accepted
+- Status: accepted (amended by [0003](0003-shared-per-jvm-cache.md) for two keys — see note below)
 - Date: 2026-07-20
 - Ticket: LSSTCCS-3029
+
+> **Amended by [ADR 0003](0003-shared-per-jvm-cache.md).** The cascade below still governs
+> per-file-system options (`CacheOptions`, `CacheFallback` policy, mount point, SSL, auth). But
+> `CacheLocation` and `CacheFallbackLocation` describe the single per-JVM cache, so 0003 pulls them
+> *out* of the per-key cascade and resolves them once, globally (test backdoor → `DEFAULT_ENV_PROPERTY`
+> → built-in default `~/ccs/cache/default`); per-FS `env` no longer supplies them. The tilde/normalize
+> handling below moves with `CacheLocation` to that global resolver.
 
 ## Context
 

--- a/docs/decisions/0002-option-resolution-cascade.md
+++ b/docs/decisions/0002-option-resolution-cascade.md
@@ -41,6 +41,17 @@ The JWT auth token, previously read straight from the raw `env` in `RestFileSyst
 read through the helper (`getAuthToken()`) so it honors the cascade too and cannot NPE on a
 null `env`.
 
+## Tilde and path normalization
+
+A `CacheLocation` supplied as a **string** (the JSON-property path — the case that never
+passes through a shell) now has a leading `~` expanded to `user.home` and is run through
+`Path.normalize()` to collapse `.`/`..`. Java has no built-in `~` expansion (it is a shell
+convention), so without this a property value like `~/ccs/cache` would create a literal `~`
+directory under the working directory. Only a leading `~` or `~/` is expanded; `~user` and
+non-leading tildes are left untouched. Values supplied as `Path` or `File` (e.g. the toolkit's
+`RemoteFileServer`, which resolves `user.home` itself) are unaffected — only the string branch
+of `getDiskCacheLocation()` changed.
+
 ## Consequences
 
 - The bootstrap can set a single system-property default (e.g.

--- a/docs/decisions/0002-option-resolution-cascade.md
+++ b/docs/decisions/0002-option-resolution-cascade.md
@@ -1,0 +1,55 @@
+# 0002 — Option resolution cascade for the ccs:// client
+
+- Status: accepted
+- Date: 2026-07-20
+- Ticket: LSSTCCS-3029
+
+## Context
+
+The CCS bootstrap adds `ccs://` file systems at JVM start, before the toolkit's
+configuration layer exists, by calling `newFileSystem(uri, null)`. The only configuration
+mechanism available that early is a system property — `DEFAULT_ENV_PROPERTY`
+(`org.lsst.ccs.rest.file.client.defaultEnvironment`), a JSON map — which is exactly what
+it was designed for.
+
+That property was effectively dead on the normal path. `RestFileSystemProvider.newFileSystem`
+substituted a non-null empty map (`NO_ENV`) when the caller passed `null`, and
+`RestFileSystemOptionsHelper` only consulted the property when its `env` was `null`. So the
+non-null empty map shadowed the property, and every bootstrap mount silently fell through to
+the hardcoded `CacheOptions.NONE` / `CacheFallback.OFFLINE`. Setting the property via `-D`
+had no effect.
+
+Separately, an explicit `env` completely *replaced* defaults rather than merging with them,
+so a caller passing a partial map lost all defaults for the keys it omitted.
+
+## Decision
+
+Resolve each option key independently through a cascade, highest precedence first:
+
+1. the explicitly supplied `env`,
+2. the programmatic default (`RestFileSystemOptions.setDefaultFileSystemEnvironment`),
+3. the `DEFAULT_ENV_PROPERTY` system-property JSON map,
+4. the hardcoded fallback in `RestFileSystemOptionsHelper.getOption`.
+
+A key present at a higher level overrides the same key lower down; keys absent higher up
+fall through. The merge happens once in the `RestFileSystemOptionsHelper` constructor, which
+builds a single merged map from all sources. This localizes resolution to the one class that
+already owned defaults and makes the system property live regardless of whether `env` is
+null or an empty map.
+
+The JWT auth token, previously read straight from the raw `env` in `RestFileSystem`, is now
+read through the helper (`getAuthToken()`) so it honors the cascade too and cannot NPE on a
+null `env`.
+
+## Consequences
+
+- The bootstrap can set a single system-property default (e.g.
+  `{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"..."}`) and every mount picks it up,
+  with per-server isolation from ADR 0001 keeping the mounts from colliding.
+- Callers passing a partial `env` now keep defaults for the keys they omit — a behavior
+  change from the previous all-or-nothing replacement, and the intended one.
+- Both default sources are static/global. Tests that set them must clear them afterward
+  (`DefaultEnvTest.clearDefaults`) to avoid leaking into other tests.
+- `RestFileSystemProvider` still substitutes the programmatic default (or an empty map) when
+  `env` is null; this is now redundant with the helper's own resolution but harmless, and
+  left in place to keep the change focused.

--- a/docs/decisions/0003-shared-per-jvm-cache.md
+++ b/docs/decisions/0003-shared-per-jvm-cache.md
@@ -45,8 +45,27 @@ The built-in default location is `~/ccs/cache/default`. The resolver expands a l
 symlink resolution or env-var expansion — the same scope as 0002, relocated to the global path
 and applied to the built-in default too.
 
-The bootstrap makes a JVM reattach to its own cache by setting a unique per-host location (e.g.
-the agent name) in the `DEFAULT_ENV_PROPERTY` JSON.
+**How the properties are set.** The global config arrives through the `DEFAULT_ENV_PROPERTY` system
+property (`org.lsst.ccs.rest.file.client.defaultEnvironment`), a JSON map carrying `CacheOptions`,
+`CacheLocation`, and (if needed) `CacheFallbackLocation`, e.g.
+
+```
+-Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/focal-plane"}'
+```
+
+Because the location is resolved **once, before the first `ccs://` file system is created**, this
+property must be in place at JVM startup — it cannot be set from application code that runs after a
+mount already exists. Two ways to set it:
+
+- **Bootstrap (preferred).** The CCS bootstrap sets the property as it launches the JVM, injecting a
+  **unique per-host location** (e.g. the agent name) so a role agent reattaches to its own cache
+  across restarts. This is the intended mechanism — the bootstrap already knows the agent identity
+  and owns JVM launch.
+- **App/launch files.** A `-D` in the app's launch configuration works for one-off or non-agent JVMs,
+  but the operator is then responsible for location uniqueness.
+
+A JVM that sets neither falls to the built-in default `~/ccs/cache/default` (shared, non-reattaching —
+fine for anonymous shells).
 
 ### 3. Lock guards cross-JVM only; same-JVM mounts share
 

--- a/docs/decisions/0003-shared-per-jvm-cache.md
+++ b/docs/decisions/0003-shared-per-jvm-cache.md
@@ -1,0 +1,63 @@
+# 0003 — One shared cache per JVM, policy in the file system
+
+- Status: proposed (supersedes much of [0001](0001-per-file-system-cache-isolation.md); keeps [0002](0002-option-resolution-cascade.md))
+- Date: 2026-07-20
+- Ticket: LSSTCCS-3029
+
+## Context
+
+ADR 0001 gave each `ccs://` file system its own JCS region and disk subdirectory to stop
+multiple mounts in one JVM from colliding on the cache lock. Tony (the original author of the
+lock) clarified its intent: the lock guards against a **different JVM on the host** reusing the
+same cache directory. It was never meant to keep file systems *within one JVM* apart.
+
+The requirement is now the opposite of 0001: a JVM with several remote file systems should use
+**one** cache location backed by **one** storage, shared by all its mounts. This is driven by
+`ccs-shell` and `ccs-console`, which read dictionaries. The cache exists so camera subsystems
+**start when the server is down**, from the freshest data they already hold.
+
+Two facts make this safe. Dictionary URLs embed a checksum, so cached content is immutable per
+URL — "never expire" is correct, not stale. Agent-name uniqueness is enforced by the messaging
+system, so a role agent (`focal-plane`, `mcm`, …) is the only holder of its name and reattaches
+to its own cache across restarts; shells/consoles get unique, non-reproducible names and simply
+do not reattach, which is acceptable.
+
+## Decision
+
+1. **One cache per JVM.** A single location, JCS region, and disk store shared by every mount.
+   This reverts 0001's per-file-system region and subdirectory.
+
+2. **Location from the bootstrap.** The bootstrap sets a unique cache name via the
+   `DEFAULT_ENV_PROPERTY` system property, delivered by the 0002 cascade. This requires a
+   coordinated toolkit change: `RemoteFileServer.createFileSystem` must stop setting
+   `CacheLocation` so the property reaches every mount (explicit env wins the cascade).
+
+3. **Lock returns to its original role.** It guards only against another JVM on the host using
+   the same location. On collision the location spills to `<name>-1`, `-2`, … Because role names
+   are unique, spill is an anomaly path for them; shells that collide spill and don't reattach.
+
+4. **Policy moves out of `Cache` into the file system.** `Cache` becomes policy-free storage
+   (`URI → CacheEntry` + disk/lock). The expiry decision — today `Cache.doEntriesExpire()`,
+   i.e. `fallback != WHEN_POSSIBLE` — moves into the per-mount `CacheRequestFilter`, which
+   already owns the `cacheOnly`/offline half. Without this, a shared `Cache`'s single
+   `cacheFallback` field would force one policy on all mounts — and the toolkit already runs
+   config/persistence as `OFFLINE` alongside dictionaries as `WHEN_POSSIBLE` in one JVM.
+
+## Consequences
+
+- Reverts 0001: the per-server region/subdir logic, the `.ccf` tokenization, and
+  `multiServerSharedBaseTest` are removed or rewritten. `cacheLockTest`'s original premise
+  (cross-process contention) is restored.
+- Sharing a region means sharing its `MaxObjects` budget (1000 in the `.ccf`); mounts can evict
+  each other. Likely needs raising. Eviction is cheap here — an evicted immutable entry is
+  re-fetched, or fails per the rules below.
+- Accepted failures: no free cache slot after spill → fail at construction (3a); offline with an
+  uncached entry → fail at read (3b). The cache is a best-effort warm-start reservoir; both
+  failures are allowed to be loud.
+- `CacheEntry.isExpired` (serialized but always overwritten) is removed; `SpeedTest`'s
+  `setCacheFallbackOption` hook moves to the file system.
+
+## Out of scope
+
+The `MaxObjects` value and the per-agent-category default policy (`OFFLINE` vs `WHEN_POSSIBLE`,
+memory vs disk) are deployment-config choices, tracked in HANDOFF.

--- a/docs/decisions/0003-shared-per-jvm-cache.md
+++ b/docs/decisions/0003-shared-per-jvm-cache.md
@@ -1,7 +1,7 @@
-# 0003 — One shared cache per JVM, policy in the file system
+# 0003 — One shared cache per JVM, global cache config, policy in the file system
 
-- Status: proposed (supersedes much of [0001](0001-per-file-system-cache-isolation.md); keeps [0002](0002-option-resolution-cascade.md))
-- Date: 2026-07-20
+- Status: proposed (supersedes much of [0001](0001-per-file-system-cache-isolation.md); amends [0002](0002-option-resolution-cascade.md))
+- Date: 2026-07-20 (design refined 2026-07-21)
 - Ticket: LSSTCCS-3029
 
 ## Context
@@ -11,9 +11,9 @@ multiple mounts in one JVM from colliding on the cache lock. Tony (the original 
 lock) clarified its intent: the lock guards against a **different JVM on the host** reusing the
 same cache directory. It was never meant to keep file systems *within one JVM* apart.
 
-The requirement is now the opposite of 0001: a JVM with several remote file systems should use
+The requirement is the opposite of 0001: a JVM with several remote file systems should use
 **one** cache location backed by **one** storage, shared by all its mounts. This is driven by
-`ccs-shell` and `ccs-console`, which read dictionaries. The cache exists so camera subsystems
+`ccs-shell` and `ccs-console`, which read dictionaries; the cache exists so camera subsystems
 **start when the server is down**, from the freshest data they already hold.
 
 Two facts make this safe. Dictionary URLs embed a checksum, so cached content is immutable per
@@ -24,40 +24,79 @@ do not reattach, which is acceptable.
 
 ## Decision
 
-1. **One cache per JVM.** A single location, JCS region, and disk store shared by every mount.
-   This reverts 0001's per-file-system region and subdirectory.
+### 1. One cache per JVM
 
-2. **Location from the bootstrap.** The bootstrap sets a unique cache name via the
-   `DEFAULT_ENV_PROPERTY` system property, delivered by the 0002 cascade. This requires a
-   coordinated toolkit change: `RemoteFileServer.createFileSystem` must stop setting
-   `CacheLocation` so the property reaches every mount (explicit env wins the cascade).
+A single location, JCS region (`default`), and disk store shared by every mount. This reverts
+0001's per-file-system region and subdirectory and the `.ccf` tokenization. `MaxObjects` in
+`memory.ccf` rises to **2500** since mounts now share one region's budget.
 
-3. **Lock returns to its original role.** It guards only against another JVM on the host using
-   the same location. On collision the location spills to `<name>-1`, `-2`, … Because role names
-   are unique, spill is an anomaly path for them; shells that collide spill and don't reattach.
+### 2. Cache location and spill flag are JVM-global
 
-4. **Policy moves out of `Cache` into the file system.** `Cache` becomes policy-free storage
-   (`URI → CacheEntry` + disk/lock). The expiry decision — today `Cache.doEntriesExpire()`,
-   i.e. `fallback != WHEN_POSSIBLE` — moves into the per-mount `CacheRequestFilter`, which
-   already owns the `cacheOnly`/offline half. Without this, a shared `Cache`'s single
-   `cacheFallback` field would force one policy on all mounts — and the toolkit already runs
-   config/persistence as `OFFLINE` alongside dictionaries as `WHEN_POSSIBLE` in one JVM.
+`CacheLocation` and `CacheFallbackLocation` (the spill flag) describe the single per-JVM cache, so
+they are resolved **once, before the first file system is created**, and *not* per mount. Their
+resolution order is: a package-private test backdoor → the `DEFAULT_ENV_PROPERTY` JSON map → a
+built-in default. Per-file-system `env` no longer supplies these two keys; the builder methods
+`cacheLocation()` and `ignoreLockedCache()` are `@Deprecated` and become **no-ops**. This
+**amends [0002](0002-option-resolution-cascade.md)**, which resolved *every* key through the
+per-key cascade — these two keys now leave it.
+
+The built-in default location is `~/ccs/cache/default`. The resolver expands a leading `~`
+(`~` or `~/…`; `~user` untouched) and applies lexical `Path.normalize()` (`./`, `../`), with no
+symlink resolution or env-var expansion — the same scope as 0002, relocated to the global path
+and applied to the built-in default too.
+
+The bootstrap makes a JVM reattach to its own cache by setting a unique per-host location (e.g.
+the agent name) in the `DEFAULT_ENV_PROPERTY` JSON.
+
+### 3. Lock guards cross-JVM only; same-JVM mounts share
+
+The lock on `<loc>/lockFile` has three outcomes, distinguished by JVM-scoped `FileLock` semantics:
+
+- **`tryLock()` returns a lock** — nobody holds it. This mount owns the location; keep the lock.
+- **`OverlappingFileLockException`** — another mount in *this* JVM already holds it. Share the
+  location: take no lock, close the probe channel, stop. (JCS region and disk store are JVM-wide
+  singletons, so sharing is automatic once the lock stops rejecting us.)
+- **`tryLock()` returns `null`** — another *process* holds it. Spill to `<loc>-1`, `-2`, … if the
+  global spill flag is set, else fail "in use".
+
+A foreign process yields `null`; our own JVM *throws* — that asymmetry is what separates "share"
+from "spill". The spill flag defaults to `false` (fail loud), so a non-unique location surfaces as
+an error rather than silently degrading. Deployments that want anonymous shells to spill set
+`CacheFallbackLocation:true` in the JSON. Spill acts on the *resolved* location regardless of
+provenance: a non-unique *provided* location spills exactly as the default does.
+
+Known limitation: the OS lock is held by whichever mount acquired it first and released when
+*that* mount closes, not when the last sharer closes. Bootstrap mounts live for the JVM lifetime
+and close together, so this is low risk.
+
+### 4. Policy moves out of `Cache` into the file system
+
+`Cache` becomes policy-free storage (`URI → CacheEntry` + disk/lock). The expiry decision — today
+`Cache.doEntriesExpire()`, i.e. `fallback != WHEN_POSSIBLE` — moves into the per-mount
+`CacheRequestFilter`, which already owns the `cacheOnly`/offline half. Without this, a shared
+`Cache`'s single `cacheFallback` field would force one policy on all mounts — and the toolkit runs
+config/persistence as `OFFLINE` alongside dictionaries as `WHEN_POSSIBLE` in one JVM. So
+`CacheOptions` and the `CacheFallback` *policy* stay per-file-system (via the 0002 cascade);
+only the two location keys go global. `CacheOptions` keeps its `NONE` default — caching is opt-in
+via the JSON, so plain callers do not write a disk cache under the always-present default location.
 
 ## Consequences
 
-- Reverts 0001: the per-server region/subdir logic, the `.ccf` tokenization, and
-  `multiServerSharedBaseTest` are removed or rewritten. `cacheLockTest`'s original premise
-  (cross-process contention) is restored.
-- Sharing a region means sharing its `MaxObjects` budget (1000 in the `.ccf`); mounts can evict
-  each other. Likely needs raising. Eviction is cheap here — an evicted immutable entry is
-  re-fetched, or fails per the rules below.
-- Accepted failures: no free cache slot after spill → fail at construction (3a); offline with an
-  uncached entry → fail at read (3b). The cache is a best-effort warm-start reservoir; both
-  failures are allowed to be loud.
-- `CacheEntry.isExpired` (serialized but always overwritten) is removed; `SpeedTest`'s
-  `setCacheFallbackOption` hook moves to the file system.
+- Reverts 0001: per-server region/subdir logic, `.ccf` tokenization, and `multiServerSharedBaseTest`
+  are removed or rewritten.
+- The client stops *reading* per-FS `CacheLocation`/`CacheFallbackLocation`, so the toolkit's
+  `.cacheLocation()`/`.ignoreLockedCache()` calls (client 1.1.8) become inert without a rebuild.
+  The toolkit change is therefore **cosmetic cleanup, not a required coordinated change**.
+- Sharing one region means sharing its `MaxObjects` budget (now 2500); mounts can evict each other.
+  Eviction is cheap — an evicted immutable entry is re-fetched, or fails per the rules below.
+- Accepted failures, both allowed to be loud: no free cache slot after spill → fail at construction;
+  offline with an uncached entry → fail at read. The cache is a best-effort warm-start reservoir.
+- `CacheEntry.isExpired` (serialized but always overwritten) is removed; removing the field is
+  read-compatible with existing on-disk entries (the field in the stream is ignored), so no
+  `serialVersionUID` bump. `SpeedTest`'s `setCacheFallbackOption` hook moves to the file system.
 
 ## Out of scope
 
-The `MaxObjects` value and the per-agent-category default policy (`OFFLINE` vs `WHEN_POSSIBLE`,
-memory vs disk) are deployment-config choices, tracked in HANDOFF.
+The per-agent-category default policy (`OFFLINE` vs `WHEN_POSSIBLE`, memory vs disk) and the
+bootstrap `defaultEnvironment` values for base and summit are deployment-config choices, tracked
+in HANDOFF.

--- a/docs/decisions/0003-shared-per-jvm-cache.md
+++ b/docs/decisions/0003-shared-per-jvm-cache.md
@@ -1,6 +1,6 @@
 # 0003 — One shared cache per JVM, global cache config, policy in the file system
 
-- Status: proposed (supersedes much of [0001](0001-per-file-system-cache-isolation.md); amends [0002](0002-option-resolution-cascade.md))
+- Status: accepted (supersedes much of [0001](0001-per-file-system-cache-isolation.md); amends [0002](0002-option-resolution-cascade.md))
 - Date: 2026-07-20 (design refined 2026-07-21)
 - Ticket: LSSTCCS-3029
 
@@ -17,10 +17,16 @@ The requirement is the opposite of 0001: a JVM with several remote file systems 
 **start when the server is down**, from the freshest data they already hold.
 
 Two facts make this safe. Dictionary URLs embed a checksum, so cached content is immutable per
-URL — "never expire" is correct, not stale. Agent-name uniqueness is enforced by the messaging
-system, so a role agent (`focal-plane`, `mcm`, …) is the only holder of its name and reattaches
-to its own cache across restarts; shells/consoles get unique, non-reproducible names and simply
-do not reattach, which is acceptable.
+URL — "never expire" is correct, not stale. And the cache location keys off the **application
+name** — the name of the app file the bootstrap is launching, injected as the `<app|default>`
+token when it sets the property. This is *not* the messaging-bus agent name (which the messaging
+system does enforce unique); it is resolved at launch, before any bus identity exists. A role
+agent (`focal-plane`, `mcm`, …) is launched from its own app file, so its app name is stable and
+unique across restarts and it reattaches to its own cache. Several shells or consoles launched
+from the *same* app file share the *same* app name, so they resolve to the same cache location
+and collide — the first takes it, the rest spill to `<loc>-1`, `-2`, … (§3). Shells therefore do
+not reliably reattach to any particular cache; whichever slot is free is the one they get, which
+is acceptable — a shell that misses its previous cache just refetches.
 
 ## Decision
 

--- a/docs/decisions/0003-shared-per-jvm-cache.md
+++ b/docs/decisions/0003-shared-per-jvm-cache.md
@@ -34,9 +34,10 @@ A single location, JCS region (`default`), and disk store shared by every mount.
 
 `CacheLocation` and `CacheFallbackLocation` (the spill flag) describe the single per-JVM cache, so
 they are resolved **once, before the first file system is created**, and *not* per mount. Their
-resolution order is: a package-private test backdoor → the `DEFAULT_ENV_PROPERTY` JSON map → a
-built-in default. Per-file-system `env` no longer supplies these two keys; the builder methods
-`cacheLocation()` and `ignoreLockedCache()` are `@Deprecated` and become **no-ops**. This
+resolution order is: a programmatic override (`RestFileSystemOptions.setCacheLocation(Path)`, allowed
+only before the first cache is configured; used by the CLI's `--cacheDir`) → the `DEFAULT_ENV_PROPERTY`
+JSON map → a built-in default. Per-file-system `env` no longer supplies these two keys, and the
+per-FS builder methods `cacheLocation()` and `ignoreLockedCache()` are **removed**. This
 **amends [0002](0002-option-resolution-cascade.md)**, which resolved *every* key through the
 per-key cascade — these two keys now leave it.
 
@@ -109,9 +110,12 @@ via the JSON, so plain callers do not write a disk cache under the always-presen
 
 - Reverts 0001: per-server region/subdir logic, `.ccf` tokenization, and `multiServerSharedBaseTest`
   are removed or rewritten.
-- The client stops *reading* per-FS `CacheLocation`/`CacheFallbackLocation`, so the toolkit's
-  `.cacheLocation()`/`.ignoreLockedCache()` calls (client 1.1.8) become inert without a rebuild.
-  The toolkit change is therefore **cosmetic cleanup, not a required coordinated change**.
+- The client stops *reading* per-FS `CacheLocation`/`CacheFallbackLocation`. The per-FS builder
+  methods `cacheLocation()`/`ignoreLockedCache()` are **removed** (only this repo and the toolkit
+  used them), so the toolkit must **rebuild** against the new client and drop those calls — a
+  required coordinated change, done in the toolkit's LSSTCCS-3029 PR. (An earlier draft kept the
+  methods as deprecated no-ops for drop-in compatibility; removal was chosen since the callers are
+  all in-tree.)
 - Sharing one region means sharing its `MaxObjects` budget (now 2500); mounts can evict each other.
   Eviction is cheap — an evicted immutable entry is re-fetched, or fails per the rules below.
 - Accepted failures, both allowed to be loud: no free cache slot after spill → fail at construction;

--- a/docs/decisions/0003-shared-per-jvm-cache.md
+++ b/docs/decisions/0003-shared-per-jvm-cache.md
@@ -47,25 +47,31 @@ and applied to the built-in default too.
 
 **How the properties are set.** The global config arrives through the `DEFAULT_ENV_PROPERTY` system
 property (`org.lsst.ccs.rest.file.client.defaultEnvironment`), a JSON map carrying `CacheOptions`,
-`CacheLocation`, and (if needed) `CacheFallbackLocation`, e.g.
-
-```
--Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/focal-plane"}'
-```
-
-Because the location is resolved **once, before the first `ccs://` file system is created**, this
-property must be in place at JVM startup — it cannot be set from application code that runs after a
-mount already exists. Two ways to set it:
+`CacheLocation`, and `CacheFallbackLocation`. Because the location is resolved **once, before the
+first `ccs://` file system is created**, the property must be in place at JVM startup — it cannot be
+set from application code that runs after a mount already exists. Two ways to set it:
 
 - **Bootstrap (preferred).** The CCS bootstrap sets the property as it launches the JVM, injecting a
-  **unique per-host location** (e.g. the agent name) so a role agent reattaches to its own cache
-  across restarts. This is the intended mechanism — the bootstrap already knows the agent identity
-  and owns JVM launch.
-- **App/launch files.** A `-D` in the app's launch configuration works for one-off or non-agent JVMs,
-  but the operator is then responsible for location uniqueness.
+  **unique per-agent location** so a role agent reattaches to its own cache across restarts. It does
+  this with a `<app|default>` substitution token, resolved to the agent name at launch (see
+  [bootstrap ADR 0001](../../../org-lsst-ccs-bootstrap/docs/decisions/0001-substitution-tokens-in-java-opts.md)).
+  The shipped bootstrap `system.properties` line is:
+
+  ```
+  system.property.org.lsst.ccs.rest.file.client.defaultEnvironment={"CacheOptions":"MEMORY_AND_DISK","CacheFallbackLocation":true,"CacheLocation":"~/ccs/cache/<app|default>"}
+  ```
+
+- **App/launch files.** A literal `-D` in the app's launch configuration works for one-off or
+  non-agent JVMs, but the operator is then responsible for location uniqueness.
 
 A JVM that sets neither falls to the built-in default `~/ccs/cache/default` (shared, non-reattaching —
 fine for anonymous shells).
+
+**Delivery is decoupled from this client.** The client only reads `DEFAULT_ENV_PROPERTY`; it does not
+care whether the value came from a token-resolving bootstrap or a literal `-D`, and there is no build
+dependency on the bootstrap. The two changes are coupled only at *deployment* — a new bootstrap and a
+new client are rolled out together so production JVMs get per-agent locations — which is a deployment
+coordination note, not a constraint on the client implementation or its tests.
 
 ### 3. Lock guards cross-JVM only; same-JVM mounts share
 

--- a/docs/guides/toolkit-cache-compatibility.md
+++ b/docs/guides/toolkit-cache-compatibility.md
@@ -1,0 +1,94 @@
+# Toolkit remote-file-server cache behavior under the client changes
+
+This guide records how the toolkit's three remote file servers (configuration, persistence,
+dictionaries) behave with the LSSTCCS-3029 client changes — per-file-system cache isolation
+(ADR 0001), the option-resolution cascade (ADR 0002), and `~` expansion — and, specifically,
+whether the `DEFAULT_ENV_PROPERTY` system property alters them.
+
+## Scenario verified
+
+JVM launched with:
+
+```
+-Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/remoteFileSystem"}'
+```
+
+The `~/ccs/cache/remoteFileSystem` value was also checked against the earlier
+`/var/lib/ccs/rest-cache` variant; the conclusion is the same for both.
+
+## Toolkit classes examined
+
+All three toolkit services create their `ccs://` file system through a single factory,
+`RemoteFileServer.createFileSystem` (`core/configuration/.../RemoteFileServer.java`):
+
+- `RestFileServerRemoteDAO` — mount point `config`
+- `PersistencyService.RemotePersistencyDAO` — mount point `persistence`
+- `RemoteDictionaryDAO` — caller-supplied mount point; sets `cacheFallback=when_possible`
+
+The factory builds an **explicit** environment map with the `RestFileSystemOptions.builder()`,
+always setting `MountPoint`, `CacheLocation` (`~/ccs/cache/<cacheName>` as a `File`),
+`CacheOptions.MEMORY_AND_DISK`, `ignoreLockedCache(true)`, a `CacheFallback`, and an `SSLOptions`.
+
+## Result: the property does not change these three services
+
+The option cascade (ADR 0002) resolves each key with the explicit `env` at the **highest**
+precedence. Because the factory sets `CacheOptions` and `CacheLocation` explicitly, the
+system property's values for those keys are overridden. The property only reaches a mount for
+keys the builder leaves unset — and the builder leaves neither of the two keys in this
+property unset. So config, persistence, and dictionaries keep caching under
+`~/ccs/cache/<cacheName>/...`, not under the property's path.
+
+The `~` expansion added for string `CacheLocation` values also does not apply here: the
+factory passes `CacheLocation` as a `File` (`cacheDir.toFile()`), which resolves `user.home`
+itself and skips the string branch of `getDiskCacheLocation()` entirely.
+
+### Effective options for the three services in this scenario
+
+Assumes no `org.lsst.ccs.config.remote.cacheOnly`, and a non-dev server URI.
+
+| Option | config | persistence | dictionaries | Source (all three) |
+|--------|--------|-------------|--------------|--------------------|
+| `CacheOptions` | `MEMORY_AND_DISK` | `MEMORY_AND_DISK` | `MEMORY_AND_DISK` | explicit env (property matches, so redundant) |
+| `CacheLocation` (base) | `~/ccs/cache/<desc>/config/` | `~/ccs/cache/<desc>/persistence/` | `~/ccs/cache/<desc>/<mount>/` | explicit env — **property path ignored** |
+| `MountPoint` | `config/` | `persistence/` | `<mount>/` | explicit env |
+| `CacheFallback` | `OFFLINE` | `OFFLINE` | `WHEN_POSSIBLE` | default / default / explicit (`RemoteDictionaryDAO`) |
+| `CacheFallbackLocation` | `true` | `true` | `true` | explicit env (`ignoreLockedCache`) |
+| `UseSSL` | `AUTO`¹ | `AUTO`¹ | `AUTO`¹ | explicit env |
+| `CacheLogging` | `false` | `false` | `false` | hardcoded fallback |
+| `JWTToken` | none | none | none | hardcoded fallback |
+
+¹ `TRUE` if the server URI contains `lsst-camera-dev.slac.stanford.edu` (dev workaround);
+`AUTO` otherwise. If `org.lsst.ccs.config.remote.cacheOnly=true`, every `CacheFallback`
+becomes `ALWAYS`.
+
+## Two effects that *do* reach the services when the toolkit upgrades
+
+These follow from the client changes themselves, independent of the property:
+
+1. **Per-server disk subdirectory.** `CacheLocation` is now a base directory, so the disk
+   cache moves from `~/ccs/cache/<desc>/config/` to `~/ccs/cache/<desc>/config/<key>/`
+   (`<key>` = sanitized `getFullURI()` + short hash). Not breaking, but any existing on-disk
+   cache at the old path is orphaned — a one-time cold cache after the upgrade.
+2. **Region isolation.** Previously every mount shared the single JCS `"default"` region;
+   each now gets its own region keyed by `getFullURI()`. The three services already use
+   distinct mount points, so they become genuinely isolated, and their `ignoreLockedCache`
+   workaround is moot for distinct servers.
+
+## How this was verified, and its limits
+
+This is **source-level analysis** of the toolkit at
+`/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit` against the client on branch
+`LSSTCCS-3029` — not a runtime JVM launch. No public client API changed, so the toolkit
+compiles and links unchanged; the toolkit only uses the public builder/enum surface.
+
+Version note: the toolkit currently depends on `org-lsst-ccs-rest-file-server-client`
+**1.1.8** (`core/configuration/pom.xml`); the changes described here are on
+**1.1.10-SNAPSHOT**. The analysis describes behavior once the toolkit upgrades to a build
+containing them. A runtime cross-build (install the SNAPSHOT client locally, build the
+toolkit against it) has not been done.
+
+## Takeaway
+
+The property is safe to set: it does not change config/persistence/dictionary caching. If the
+intent is for those services to honor a central cache location, that requires a change in
+`RemoteFileServer.createFileSystem` (stop hardcoding `cacheLocation`), not in the client.

--- a/docs/guides/toolkit-cache-compatibility.md
+++ b/docs/guides/toolkit-cache-compatibility.md
@@ -43,11 +43,25 @@ half is unaffected.
 
 ## Verification
 
-Source-level analysis of the toolkit at `/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit` against the
-branch — not a runtime launch. The per-FS builder methods `cacheLocation()`/`ignoreLockedCache()` are
-**removed**, so the toolkit does not compile against the new client until its LSSTCCS-3029 PR lands
-(client bumped to **1.1.10-SNAPSHOT**, calls removed). The toolkit previously depended on client
-**1.1.8**.
+Confirmed at runtime (LSSTCCS-3029, 2026-07-21) with live CCS agents against the production dev
+server `https://lsst-camera-dev.slac.stanford.edu/RestFileServer/`, in addition to the unit suite:
+
+- **One shared region across all three services.** A `demo-subsystem` agent mounting `config`,
+  `persistence` (both `OFFLINE`) and `dictionaries` (`WHEN_POSSIBLE`) in one JVM backed onto a
+  **single** JCS `default` region and one disk store (`~/ccs/cache/demo-subsystem/default.data`,
+  no per-service subdirs) — the two policies coexisting in the shared region, exactly as designed.
+- **Warm-start offline.** With the server made unreachable, the agent went offline at mount time,
+  reattached to its own cache, and served cached `config`/`persistence` reads from disk; an
+  uncached read failed loud with `OfflineException` (the accepted failure), and once that file had
+  been cached online, the offline read succeeded.
+- **App-name cache keying.** Role agents reattach to their own cache across restarts; multiple
+  shells launched from the same app file share the app name, collide, and spill to `<loc>-N`
+  (see [ADR 0003 §3](../decisions/0003-shared-per-jvm-cache.md)). Stale locks from a killed agent
+  are reclaimed (OS releases the lock on process death).
+
+The per-FS builder methods `cacheLocation()`/`ignoreLockedCache()` are **removed**, so the toolkit
+does not compile against the new client until its LSSTCCS-3029 PR lands (client bumped to
+**1.1.11**, calls removed). The toolkit previously depended on client **1.1.8**.
 
 ## Takeaway
 

--- a/docs/guides/toolkit-cache-compatibility.md
+++ b/docs/guides/toolkit-cache-compatibility.md
@@ -1,53 +1,56 @@
 # Toolkit remote-file-server cache behavior
 
 How the toolkit's three remote file servers (configuration, persistence, dictionaries) behave
-with the LSSTCCS-3029 client changes, and whether the `DEFAULT_ENV_PROPERTY` system property
-affects them.
+with the LSSTCCS-3029 client changes, and how the `DEFAULT_ENV_PROPERTY` system property affects
+them.
 
-> **Currency:** describes the branch *as built* (ADR 0001 + 0002). [ADR 0003](../decisions/0003-shared-per-jvm-cache.md)
-> (proposed) reverses the per-server isolation in "Effects on upgrade" below and adopts the
-> toolkit change in "Takeaway". Revisit when 0003 lands.
+> **Currency:** describes the branch as built for [ADR 0003](../decisions/0003-shared-per-jvm-cache.md)
+> (one shared cache per JVM). Supersedes the earlier ADR 0001 description.
 
 ## Setup
 
 All three services create their `ccs://` file system through one factory,
-`RemoteFileServer.createFileSystem`, which builds an **explicit** env map via
-`RestFileSystemOptions.builder()` — always setting `MountPoint`, `CacheLocation`
-(`~/ccs/cache/<name>` as a `File`), `CacheOptions.MEMORY_AND_DISK`, `ignoreLockedCache(true)`,
-a `CacheFallback`, and `SSLOptions`. Mount points: `config`, `persistence`, and a
-caller-supplied one for dictionaries (which also sets `cacheFallback=WHEN_POSSIBLE`).
+`RemoteFileServer.createFileSystem`, which builds an env map via `RestFileSystemOptions.builder()` —
+setting `MountPoint`, `CacheLocation` (`~/ccs/cache/<name>` as a `File`), `CacheOptions.MEMORY_AND_DISK`,
+`ignoreLockedCache(true)`, a `CacheFallback`, and `SSLOptions`. Mount points: `config`, `persistence`,
+and a caller-supplied one for dictionaries (which sets `cacheFallback=WHEN_POSSIBLE`).
 
-Scenario checked:
-`-Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/remoteFileSystem"}'`.
+## The toolkit must rebuild against the new client
 
-## The property does not change these three services
+Under 0003 the cache **location** and the **spill flag** are JVM-global: the client resolves them
+once from `DEFAULT_ENV_PROPERTY` (or the built-in default `~/ccs/cache/default`) and no longer reads
+the per-file-system `CacheLocation` / `CacheFallbackLocation` values. The per-FS builder methods
+`cacheLocation()` and `ignoreLockedCache()` are **removed** from the client API, so the factory's
+`.cacheLocation(...)` / `.ignoreLockedCache(true)` calls no longer compile — the toolkit must rebuild
+against the new client and drop them. This is done in the toolkit's LSSTCCS-3029 PR (bump client to
+1.1.10-SNAPSHOT + remove the calls); it is a required coordinated change, not optional cleanup.
 
-The cascade (ADR 0002) resolves each key with explicit `env` at highest precedence. The factory
-sets `CacheOptions` and `CacheLocation` explicitly, so the property's values for those keys are
-overridden — it only reaches keys the builder leaves unset, and it leaves neither unset. `~`
-expansion also doesn't apply: `CacheLocation` is passed as a `File`, which skips the string
-branch of `getDiskCacheLocation()`. So the three services keep caching under
-`~/ccs/cache/<name>/...`, and the property is safe to set.
+`CacheOptions` and the `CacheFallback` policy are still per-mount, so the three services keep their
+distinct caching strategies (e.g. dictionaries `WHEN_POSSIBLE`, config/persistence `OFFLINE`) — that
+half is unaffected.
 
-## Effects on upgrade (from the client changes, not the property)
+## Effects on upgrade
 
-1. **Per-server subdirectory.** `CacheLocation` is now a base dir, so the disk cache moves to
-   `~/ccs/cache/<name>/<key>/`. Existing caches at the old path are orphaned — a one-time cold
-   cache.
-2. **Region isolation.** Each mount gets its own JCS region instead of the shared `default`.
-   The three services use distinct mount points, so they become genuinely isolated.
+1. **One shared cache per JVM.** All three services share a single JCS `default` region and one disk
+   store at the resolved global location. They no longer cache under per-service `~/ccs/cache/<name>`
+   subdirectories; existing caches at the old paths are orphaned — a one-time cold cache.
+2. **Location comes from the property, not the factory.** With the property unset, all three land on
+   `~/ccs/cache/default`. To give a JVM its own reattaching cache, set the property (the CCS bootstrap
+   does this with an `<app|default>` token — see
+   [bootstrap ADR 0001](../../../org-lsst-ccs-bootstrap/docs/decisions/0001-substitution-tokens-in-java-opts.md)).
+3. **Shared `MaxObjects` budget.** The three services share one region's budget (raised to 2500);
+   they can evict each other. Eviction is cheap — an evicted entry is re-fetched.
 
 ## Verification
 
-Source-level analysis of the toolkit at `/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit`
-against the branch — not a runtime launch. No public client API changed, so the toolkit
-compiles unchanged. The toolkit depends on client **1.1.8** (`core/configuration/pom.xml`);
-these changes are on **1.1.10-SNAPSHOT**, so the behavior above applies once it upgrades. No
-runtime cross-build done.
+Source-level analysis of the toolkit at `/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit` against the
+branch — not a runtime launch. The per-FS builder methods `cacheLocation()`/`ignoreLockedCache()` are
+**removed**, so the toolkit does not compile against the new client until its LSSTCCS-3029 PR lands
+(client bumped to **1.1.10-SNAPSHOT**, calls removed). The toolkit previously depended on client
+**1.1.8**.
 
 ## Takeaway
 
-The property is safe to set; it does not change config/persistence/dictionary caching. Making
-those services honor a central cache location requires changing
-`RemoteFileServer.createFileSystem` to stop hardcoding `CacheLocation` — which is exactly what
-ADR 0003 proposes.
+The property is safe to set and now *does* drive the toolkit services' cache location (they share one
+per-JVM cache). Adopting the new client requires the toolkit to rebuild and drop the removed
+`.cacheLocation()` / `.ignoreLockedCache()` calls — done in its LSSTCCS-3029 PR.

--- a/docs/guides/toolkit-cache-compatibility.md
+++ b/docs/guides/toolkit-cache-compatibility.md
@@ -1,94 +1,53 @@
-# Toolkit remote-file-server cache behavior under the client changes
+# Toolkit remote-file-server cache behavior
 
-This guide records how the toolkit's three remote file servers (configuration, persistence,
-dictionaries) behave with the LSSTCCS-3029 client changes — per-file-system cache isolation
-(ADR 0001), the option-resolution cascade (ADR 0002), and `~` expansion — and, specifically,
-whether the `DEFAULT_ENV_PROPERTY` system property alters them.
+How the toolkit's three remote file servers (configuration, persistence, dictionaries) behave
+with the LSSTCCS-3029 client changes, and whether the `DEFAULT_ENV_PROPERTY` system property
+affects them.
 
-## Scenario verified
+> **Currency:** describes the branch *as built* (ADR 0001 + 0002). [ADR 0003](../decisions/0003-shared-per-jvm-cache.md)
+> (proposed) reverses the per-server isolation in "Effects on upgrade" below and adopts the
+> toolkit change in "Takeaway". Revisit when 0003 lands.
 
-JVM launched with:
+## Setup
 
-```
--Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/remoteFileSystem"}'
-```
+All three services create their `ccs://` file system through one factory,
+`RemoteFileServer.createFileSystem`, which builds an **explicit** env map via
+`RestFileSystemOptions.builder()` — always setting `MountPoint`, `CacheLocation`
+(`~/ccs/cache/<name>` as a `File`), `CacheOptions.MEMORY_AND_DISK`, `ignoreLockedCache(true)`,
+a `CacheFallback`, and `SSLOptions`. Mount points: `config`, `persistence`, and a
+caller-supplied one for dictionaries (which also sets `cacheFallback=WHEN_POSSIBLE`).
 
-The `~/ccs/cache/remoteFileSystem` value was also checked against the earlier
-`/var/lib/ccs/rest-cache` variant; the conclusion is the same for both.
+Scenario checked:
+`-Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/remoteFileSystem"}'`.
 
-## Toolkit classes examined
+## The property does not change these three services
 
-All three toolkit services create their `ccs://` file system through a single factory,
-`RemoteFileServer.createFileSystem` (`core/configuration/.../RemoteFileServer.java`):
+The cascade (ADR 0002) resolves each key with explicit `env` at highest precedence. The factory
+sets `CacheOptions` and `CacheLocation` explicitly, so the property's values for those keys are
+overridden — it only reaches keys the builder leaves unset, and it leaves neither unset. `~`
+expansion also doesn't apply: `CacheLocation` is passed as a `File`, which skips the string
+branch of `getDiskCacheLocation()`. So the three services keep caching under
+`~/ccs/cache/<name>/...`, and the property is safe to set.
 
-- `RestFileServerRemoteDAO` — mount point `config`
-- `PersistencyService.RemotePersistencyDAO` — mount point `persistence`
-- `RemoteDictionaryDAO` — caller-supplied mount point; sets `cacheFallback=when_possible`
+## Effects on upgrade (from the client changes, not the property)
 
-The factory builds an **explicit** environment map with the `RestFileSystemOptions.builder()`,
-always setting `MountPoint`, `CacheLocation` (`~/ccs/cache/<cacheName>` as a `File`),
-`CacheOptions.MEMORY_AND_DISK`, `ignoreLockedCache(true)`, a `CacheFallback`, and an `SSLOptions`.
+1. **Per-server subdirectory.** `CacheLocation` is now a base dir, so the disk cache moves to
+   `~/ccs/cache/<name>/<key>/`. Existing caches at the old path are orphaned — a one-time cold
+   cache.
+2. **Region isolation.** Each mount gets its own JCS region instead of the shared `default`.
+   The three services use distinct mount points, so they become genuinely isolated.
 
-## Result: the property does not change these three services
+## Verification
 
-The option cascade (ADR 0002) resolves each key with the explicit `env` at the **highest**
-precedence. Because the factory sets `CacheOptions` and `CacheLocation` explicitly, the
-system property's values for those keys are overridden. The property only reaches a mount for
-keys the builder leaves unset — and the builder leaves neither of the two keys in this
-property unset. So config, persistence, and dictionaries keep caching under
-`~/ccs/cache/<cacheName>/...`, not under the property's path.
-
-The `~` expansion added for string `CacheLocation` values also does not apply here: the
-factory passes `CacheLocation` as a `File` (`cacheDir.toFile()`), which resolves `user.home`
-itself and skips the string branch of `getDiskCacheLocation()` entirely.
-
-### Effective options for the three services in this scenario
-
-Assumes no `org.lsst.ccs.config.remote.cacheOnly`, and a non-dev server URI.
-
-| Option | config | persistence | dictionaries | Source (all three) |
-|--------|--------|-------------|--------------|--------------------|
-| `CacheOptions` | `MEMORY_AND_DISK` | `MEMORY_AND_DISK` | `MEMORY_AND_DISK` | explicit env (property matches, so redundant) |
-| `CacheLocation` (base) | `~/ccs/cache/<desc>/config/` | `~/ccs/cache/<desc>/persistence/` | `~/ccs/cache/<desc>/<mount>/` | explicit env — **property path ignored** |
-| `MountPoint` | `config/` | `persistence/` | `<mount>/` | explicit env |
-| `CacheFallback` | `OFFLINE` | `OFFLINE` | `WHEN_POSSIBLE` | default / default / explicit (`RemoteDictionaryDAO`) |
-| `CacheFallbackLocation` | `true` | `true` | `true` | explicit env (`ignoreLockedCache`) |
-| `UseSSL` | `AUTO`¹ | `AUTO`¹ | `AUTO`¹ | explicit env |
-| `CacheLogging` | `false` | `false` | `false` | hardcoded fallback |
-| `JWTToken` | none | none | none | hardcoded fallback |
-
-¹ `TRUE` if the server URI contains `lsst-camera-dev.slac.stanford.edu` (dev workaround);
-`AUTO` otherwise. If `org.lsst.ccs.config.remote.cacheOnly=true`, every `CacheFallback`
-becomes `ALWAYS`.
-
-## Two effects that *do* reach the services when the toolkit upgrades
-
-These follow from the client changes themselves, independent of the property:
-
-1. **Per-server disk subdirectory.** `CacheLocation` is now a base directory, so the disk
-   cache moves from `~/ccs/cache/<desc>/config/` to `~/ccs/cache/<desc>/config/<key>/`
-   (`<key>` = sanitized `getFullURI()` + short hash). Not breaking, but any existing on-disk
-   cache at the old path is orphaned — a one-time cold cache after the upgrade.
-2. **Region isolation.** Previously every mount shared the single JCS `"default"` region;
-   each now gets its own region keyed by `getFullURI()`. The three services already use
-   distinct mount points, so they become genuinely isolated, and their `ignoreLockedCache`
-   workaround is moot for distinct servers.
-
-## How this was verified, and its limits
-
-This is **source-level analysis** of the toolkit at
-`/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit` against the client on branch
-`LSSTCCS-3029` — not a runtime JVM launch. No public client API changed, so the toolkit
-compiles and links unchanged; the toolkit only uses the public builder/enum surface.
-
-Version note: the toolkit currently depends on `org-lsst-ccs-rest-file-server-client`
-**1.1.8** (`core/configuration/pom.xml`); the changes described here are on
-**1.1.10-SNAPSHOT**. The analysis describes behavior once the toolkit upgrades to a build
-containing them. A runtime cross-build (install the SNAPSHOT client locally, build the
-toolkit against it) has not been done.
+Source-level analysis of the toolkit at `/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit`
+against the branch — not a runtime launch. No public client API changed, so the toolkit
+compiles unchanged. The toolkit depends on client **1.1.8** (`core/configuration/pom.xml`);
+these changes are on **1.1.10-SNAPSHOT**, so the behavior above applies once it upgrades. No
+runtime cross-build done.
 
 ## Takeaway
 
-The property is safe to set: it does not change config/persistence/dictionary caching. If the
-intent is for those services to honor a central cache location, that requires a change in
-`RemoteFileServer.createFileSystem` (stop hardcoding `cacheLocation`), not in the client.
+The property is safe to set; it does not change config/persistence/dictionary caching. Making
+those services honor a central cache location requires changing
+`RemoteFileServer.createFileSystem` to stop hardcoding `CacheLocation` — which is exactly what
+ADR 0003 proposes.

--- a/docs/guides/toolkit-cache-compatibility.md
+++ b/docs/guides/toolkit-cache-compatibility.md
@@ -23,7 +23,7 @@ the per-file-system `CacheLocation` / `CacheFallbackLocation` values. The per-FS
 `cacheLocation()` and `ignoreLockedCache()` are **removed** from the client API, so the factory's
 `.cacheLocation(...)` / `.ignoreLockedCache(true)` calls no longer compile — the toolkit must rebuild
 against the new client and drop them. This is done in the toolkit's LSSTCCS-3029 PR (bump client to
-1.1.10-SNAPSHOT + remove the calls); it is a required coordinated change, not optional cleanup.
+1.1.11 + remove the calls); it is a required coordinated change, not optional cleanup.
 
 `CacheOptions` and the `CacheFallback` policy are still per-mount, so the three services keep their
 distinct caching strategies (e.g. dictionaries `WHEN_POSSIBLE`, config/persistence `OFFLINE`) — that

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -14,6 +14,11 @@ stays per-mount. Now recorded in [ADR 0003](../decisions/0003-shared-per-jvm-cac
 amends [0002](../decisions/0002-option-resolution-cascade.md)). No 0003 code written yet — the branch
 still contains the 0001 isolation code that 0003 unwinds.
 
+The **bootstrap half is done**: the `<app|default>` token + `getJavaOpts` resolution and the shipped
+`defaultEnvironment` line are implemented, tested, and in PR
+(`org-lsst-ccs-bootstrap` PR #20, branch `LSSTCCS-3029`). It's runtime-coupled only — no build
+dependency, does not block this client work (see the workplan's deployment section).
+
 ## Next up
 
 **Build ADR 0003 per the workplan:**

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -8,30 +8,21 @@
 Branch `LSSTCCS-3029` has the ADR 0001 + 0002 work implemented, tested (35 client tests pass),
 and committed (`666f59c` isolation, `7ecd9ea` cascade, `781dcb9` ~ expansion, `4a19526` docs).
 
-A design session with Tony then **reversed direction on 0001**. See
-[ADR 0003](../decisions/0003-shared-per-jvm-cache.md) (proposed): one shared cache per JVM
-instead of per-file-system isolation. 0002 (the option cascade) stands and is depended on. No
-0003 code written yet — the branch still contains the 0001 isolation code that 0003 unwinds.
+A design session with Tony reversed direction on 0001. The 2026-07-21 brainstorm settled the full
+design: **one shared cache per JVM**, cache location + spill flag go **JVM-global**, caching policy
+stays per-mount. Now recorded in [ADR 0003](../decisions/0003-shared-per-jvm-cache.md) (proposed,
+amends [0002](../decisions/0002-option-resolution-cascade.md)). No 0003 code written yet — the branch
+still contains the 0001 isolation code that 0003 unwinds.
 
 ## Next up
 
-Implement ADR 0003 (client + a coordinated toolkit change):
-
-1. **Client — collapse to one cache per JVM.** Undo 0001's per-server region + disk subdir and
-   `.ccf` tokenization in `Cache`. Restore the lock as a cross-JVM-only guard with `<name>-N`
-   spill on collision.
-2. **Client — move policy out of `Cache`.** Make `Cache` policy-free storage; move the expiry
-   decision (`doEntriesExpire`) into the per-mount `CacheRequestFilter`. Drop
-   `CacheEntry.isExpired` and `setCacheFallbackOption`; adjust `SpeedTest`.
-3. **Client — tests.** Remove/rewrite `multiServerSharedBaseTest`; restore `cacheLockTest`'s
-   cross-process premise.
-4. **Toolkit.** `RemoteFileServer.createFileSystem` must stop setting `CacheLocation` so the
-   bootstrap system-property name reaches every mount. Toolkit is at
-   `/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit` (still on client 1.1.8).
+**Build ADR 0003 per the workplan:**
+[LSSTCCS-3029 — One shared cache per JVM](LSSTCCS-3029-shared-per-jvm-cache.md). It holds the full
+step-by-step (client-only for correctness; toolkit is non-blocking cleanup). The design decisions
+live in ADR 0003; this workplan is the how, and is the doc to share with Tony.
 
 ## Deferred (deployment-config, not code)
 
-- Raise `MaxObjects` in the `.ccf` — mounts now share one region's budget.
 - Per-agent-category default policy: role agents (unique, reproducible names) reattach with a
   persistent disk cache; `ccs-shell`/`ccs-console` (unique, non-reproducible names) don't
   reattach — decide `OFFLINE` vs `WHEN_POSSIBLE` and memory vs disk per category.

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -1,7 +1,7 @@
 # HANDOFF
 
-- Anchor: branch `LSSTCCS-3029`, at commit `7cb189f` (pushed) + an uncommitted working tree (below).
-- On resume: `git log --oneline main..HEAD` for branch history; `git status` for the working tree.
+- Anchor: branch `LSSTCCS-3029`, at commit `490a3bf` (pushed; working tree clean).
+- On resume: `git log --oneline main..HEAD` for branch history.
 
 ## State
 
@@ -10,20 +10,23 @@
 per-FS `cacheLocation()`/`ignoreLockedCache()` builder methods removed and replaced by a set-once
 `setCacheLocation(Path)` that also backs the CLI's `--cacheDir`).
 
-- **rest-file-server (this repo):** 0003 implemented + API cleanup, committed through `7cb189f`
+- **rest-file-server (this repo):** 0003 implemented + API cleanup, committed through `490a3bf`
   (pushed; `origin/LSSTCCS-3029` is level with HEAD). `mvn -pl war,client -am install` green
-  (client 43 tests, war 9). **PR not yet opened.**
+  (client 43 tests, war 9). **PR #13** (open, approved by tony-johnson; `490a3bf` — the spill fix +
+  test cleanup + this doc refresh — landed after that approval, so may warrant a re-review).
 - **bootstrap:** `<app|default>` token + shipped `defaultEnvironment` line — committed, pushed, PR #20.
 - **toolkit:** client bumped to 1.1.11 + `RemoteFileServer` cleanup — committed, pushed, PR #316.
 
 Coupled only at deployment (no build dependency beyond the toolkit's declared client version); roll
 out together.
 
-**Uncommitted working tree (this session):**
+**Landed this session in `490a3bf`:**
 - `Cache.java` — **spill-naming bug fix** (see below).
 - `CacheLockCrossJvmTest.java` — new two-level spill regression test + `@TempDir`.
 - `CachingTest.java`, `VersionedFileTest.java`, `SpeedTest.java` — `@TempDir` cleanup so tests no
   longer leak `/tmp/rfs*` dirs (`SpeedTest` migrated JUnit 4 → Jupiter).
+- The five `docs/` updates (ADR 0003 accepted; app-name Context; guide runtime verification;
+  workplan; this file).
 
 ## This session (2026-07-21)
 
@@ -41,8 +44,9 @@ out together.
 
 ## Next up
 
-- **Commit this session's working tree** (spill fix + test cleanup) and **open this repo's PR** — the
-  linchpin the toolkit/bootstrap PRs pair with.
+- **Land PR #13** (this repo — the linchpin the toolkit/bootstrap PRs pair with). Consider a
+  re-review of `490a3bf`, which landed after the existing approval. Then merge the three PRs
+  together (#13 + toolkit #316 + bootstrap #20 — deployment-coupled).
 - Optional: full toolkit reactor build (`mvn install`) to confirm nothing downstream of
   `core/configuration` breaks (only that module + deps built so far).
 - Then the deferred deployment-config items below.

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -5,25 +5,34 @@
 
 ## State
 
-Two changes on branch `LSSTCCS-3029`, **implemented and tested, not yet merged**. All 35
-client tests pass.
+Branch `LSSTCCS-3029` has the ADR 0001 + 0002 work implemented, tested (35 client tests pass),
+and committed (`666f59c` isolation, `7ecd9ea` cascade, `781dcb9` ~ expansion, `4a19526` docs).
 
-1. **Per-file-system cache isolation** (ADR 0001, workplan LSSTCCS-3029). Each `ccs://` file
-   system gets its own JCS region and disk directory, keyed off a stable hash of
-   `getFullURI()`. `CACHE_LOCATION` is now a *base* directory; each server caches under
-   `<base>/<key>`. Committed as `666f59c`. The ADR's main risk is resolved: repeated
-   `ccm.configure(props)` on the singleton **accumulates** regions rather than resetting them.
-
-2. **Option resolution cascade** (ADR 0002). Options now resolve per key: explicit env →
-   programmatic default → `DEFAULT_ENV_PROPERTY` system property → hardcoded fallback, merged
-   in the `RestFileSystemOptionsHelper` constructor. This makes the system property live on
-   the bootstrap `newFileSystem(uri, null)` path (it was previously shadowed by the non-null
-   empty `NO_ENV` map). Auth token now read through the helper too. Not yet committed.
+A design session with Tony then **reversed direction on 0001**. See
+[ADR 0003](../decisions/0003-shared-per-jvm-cache.md) (proposed): one shared cache per JVM
+instead of per-file-system isolation. 0002 (the option cascade) stands and is depended on. No
+0003 code written yet — the branch still contains the 0001 isolation code that 0003 unwinds.
 
 ## Next up
 
-- Commit the cascade work (ADR 0002 + helper/provider/RestFileSystem/DefaultEnvTest changes).
-- Review + merge branch `LSSTCCS-3029`.
-- Decide and set the actual bootstrap default policy (e.g. system property
-  `{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"..."}`) — the mechanism now works; the
-  chosen values/location for base and summit are a deployment-config decision, not code.
+Implement ADR 0003 (client + a coordinated toolkit change):
+
+1. **Client — collapse to one cache per JVM.** Undo 0001's per-server region + disk subdir and
+   `.ccf` tokenization in `Cache`. Restore the lock as a cross-JVM-only guard with `<name>-N`
+   spill on collision.
+2. **Client — move policy out of `Cache`.** Make `Cache` policy-free storage; move the expiry
+   decision (`doEntriesExpire`) into the per-mount `CacheRequestFilter`. Drop
+   `CacheEntry.isExpired` and `setCacheFallbackOption`; adjust `SpeedTest`.
+3. **Client — tests.** Remove/rewrite `multiServerSharedBaseTest`; restore `cacheLockTest`'s
+   cross-process premise.
+4. **Toolkit.** `RemoteFileServer.createFileSystem` must stop setting `CacheLocation` so the
+   bootstrap system-property name reaches every mount. Toolkit is at
+   `/home/turri/Code/LSST/ccs/org-lsst-ccs-toolkit` (still on client 1.1.8).
+
+## Deferred (deployment-config, not code)
+
+- Raise `MaxObjects` in the `.ccf` — mounts now share one region's budget.
+- Per-agent-category default policy: role agents (unique, reproducible names) reattach with a
+  persistent disk cache; `ccs-shell`/`ccs-console` (unique, non-reproducible names) don't
+  reattach — decide `OFFLINE` vs `WHEN_POSSIBLE` and memory vs disk per category.
+- Bootstrap default `defaultEnvironment` values/location for base and summit.

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -5,36 +5,25 @@
 
 ## State
 
-Per-file-system cache isolation (LSSTCCS-3029) is **implemented and tested** — not yet
-merged. Each `ccs://` file system now gets its own JCS region and its own disk directory,
-keyed off a stable hash of `getFullURI()`. `CACHE_LOCATION` is now a *base* directory; each
-server caches under `<base>/<key>`. Changes: `Cache.java` (per-server key, region, disk
-subdir, `getRegion()`/`getDiskCacheLocation()` getters), `RestFileSystem.java` (passes
-`getFullURI()` to `Cache`), `disk.ccf` (tokenized `%REGION%`/`%AUX%`), and `CachingTest.java`
-(rewrote `cacheLockTest` for same-server contention, added `multiServerSharedBaseTest`).
+Two changes on branch `LSSTCCS-3029`, **implemented and tested, not yet merged**. All 35
+client tests pass.
 
-All 32 client tests pass. The ADR's main risk is resolved: repeated `ccm.configure(props)`
-on the singleton **accumulates** regions rather than resetting them.
+1. **Per-file-system cache isolation** (ADR 0001, workplan LSSTCCS-3029). Each `ccs://` file
+   system gets its own JCS region and disk directory, keyed off a stable hash of
+   `getFullURI()`. `CACHE_LOCATION` is now a *base* directory; each server caches under
+   `<base>/<key>`. Committed as `666f59c`. The ADR's main risk is resolved: repeated
+   `ccm.configure(props)` on the singleton **accumulates** regions rather than resetting them.
 
-Background from the investigation: previously every `Cache` used the JVM-global
-`CompositeCacheManager` singleton with the hardcoded region `"default"` / auxiliary `"DC"`,
-so all file systems shared one region, disk store, and memory budget — and two
-`MEMORY_AND_DISK` mounts sharing a `CACHE_LOCATION` collided on the disk lock. See ADR 0001
-and workplan LSSTCCS-3029.
+2. **Option resolution cascade** (ADR 0002). Options now resolve per key: explicit env →
+   programmatic default → `DEFAULT_ENV_PROPERTY` system property → hardcoded fallback, merged
+   in the `RestFileSystemOptionsHelper` constructor. This makes the system property live on
+   the bootstrap `newFileSystem(uri, null)` path (it was previously shadowed by the non-null
+   empty `NO_ENV` map). Auth token now read through the helper too. Not yet committed.
 
 ## Next up
 
-- Review + merge LSSTCCS-3029.
-- Then tackle the default-policy / wiring gap below (isolation is now safe under multiple
-  mounts, so the sequencing precondition is met).
-
-## Backlog / deferred
-
-- **Default policy at bootstrap + system-property wiring gap.** We want bootstrap mounts to
-  default to `MEMORY_AND_DISK`, but `RestFileSystemProvider.newFileSystem` (`:66-69`) sets
-  `env = NO_ENV` (a non-null empty map) when the caller passes `null`, which shadows the
-  `DEFAULT_ENV_PROPERTY` system property — `RestFileSystemOptionsHelper` only consults the
-  property when `env` is null (`:31-37`), so the property is effectively dead on the normal
-  path. Needs a decision on resolution order (per-key cascade vs. coarse first-non-empty)
-  and where to resolve it. Graduate to its own ADR + workplan when it firms up. Sequencing:
-  the isolation work (3029) should land first so the default is safe under multiple mounts.
+- Commit the cascade work (ADR 0002 + helper/provider/RestFileSystem/DefaultEnvTest changes).
+- Review + merge branch `LSSTCCS-3029`.
+- Decide and set the actual bootstrap default policy (e.g. system property
+  `{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"..."}`) — the mechanism now works; the
+  chosen values/location for base and summit are a deployment-config decision, not code.

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -16,7 +16,7 @@ methods removed and replaced by a set-once `setCacheLocation(Path)` that also ba
   refresh are not yet committed. No PR opened yet.
 - **bootstrap:** `<app|default>` token + shipped `defaultEnvironment` line — committed, pushed,
   PR #20.
-- **toolkit:** client bumped to 1.1.10-SNAPSHOT + `RemoteFileServer` cleanup — committed, pushed,
+- **toolkit:** client bumped to 1.1.11 + `RemoteFileServer` cleanup — committed, pushed,
   PR #316.
 
 The three are coupled only at deployment (no build dependency on each other's SNAPSHOTs beyond the

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -1,41 +1,64 @@
 # HANDOFF
 
-- Anchor: branch `LSSTCCS-3029`, as of the commit that carries this file.
-- On resume: `git log --oneline main..HEAD` to see what moved on the branch.
+- Anchor: branch `LSSTCCS-3029`, at commit `7cb189f` (pushed) + an uncommitted working tree (below).
+- On resume: `git log --oneline main..HEAD` for branch history; `git status` for the working tree.
 
 ## State
 
-**ADR 0003 is implemented across all three repos** (one shared cache per JVM; cache location + spill
-flag JVM-global; caching policy per-mount; the per-FS `cacheLocation()`/`ignoreLockedCache()` builder
-methods removed and replaced by a set-once `setCacheLocation(Path)` that also backs the CLI's
-`--cacheDir`).
+**ADR 0003 is implemented, committed, pushed, and now runtime-verified** across all three repos
+(one shared cache per JVM; cache location + spill flag JVM-global; caching policy per-mount; the
+per-FS `cacheLocation()`/`ignoreLockedCache()` builder methods removed and replaced by a set-once
+`setCacheLocation(Path)` that also backs the CLI's `--cacheDir`).
 
-- **rest-file-server (this repo):** 0003 implemented + the API cleanup, `mvn install` green
-  (client 42 tests, war 9, cli builds). **Working tree is uncommitted** — the docs are committed
-  through `ae22a5c` (that commit is also unpushed); the 0003 client/cli implementation + this doc
-  refresh are not yet committed. No PR opened yet.
-- **bootstrap:** `<app|default>` token + shipped `defaultEnvironment` line — committed, pushed,
-  PR #20.
-- **toolkit:** client bumped to 1.1.11 + `RemoteFileServer` cleanup — committed, pushed,
-  PR #316.
+- **rest-file-server (this repo):** 0003 implemented + API cleanup, committed through `7cb189f`
+  (pushed; `origin/LSSTCCS-3029` is level with HEAD). `mvn -pl war,client -am install` green
+  (client 43 tests, war 9). **PR not yet opened.**
+- **bootstrap:** `<app|default>` token + shipped `defaultEnvironment` line — committed, pushed, PR #20.
+- **toolkit:** client bumped to 1.1.11 + `RemoteFileServer` cleanup — committed, pushed, PR #316.
 
-The three are coupled only at deployment (no build dependency on each other's SNAPSHOTs beyond the
-toolkit's declared versions); roll out together.
+Coupled only at deployment (no build dependency beyond the toolkit's declared client version); roll
+out together.
+
+**Uncommitted working tree (this session):**
+- `Cache.java` — **spill-naming bug fix** (see below).
+- `CacheLockCrossJvmTest.java` — new two-level spill regression test + `@TempDir`.
+- `CachingTest.java`, `VersionedFileTest.java`, `SpeedTest.java` — `@TempDir` cleanup so tests no
+  longer leak `/tmp/rfs*` dirs (`SpeedTest` migrated JUnit 4 → Jupiter).
+
+## This session (2026-07-21)
+
+- **Test cleanup:** the cache tests leaked a `/tmp/rfs*` dir per run (JCS files + lockFile). Moved
+  all four to JUnit 5 `@TempDir`; JUnit now deletes each tree. Verified zero leak after a full run.
+- **Live runtime verification** against the dev server (`lsst-camera-dev`), the first non-source
+  check of the 0003 model — see the [toolkit guide](../guides/toolkit-cache-compatibility.md)
+  Verification section. Covered: warm-start offline + reattach; one shared region with mixed
+  `OFFLINE`/`WHEN_POSSIBLE` mounts; spill; stale-lock reclaim after `kill -9`.
+- **Spill-naming bug found & fixed.** `Cache.lockCacheLocation` suffixed the already-suffixed
+  candidate, so successive spills compounded (`<base>-1-2-3`) instead of flat `<base>-2`, `-3`. Safe
+  (distinct exclusively-locked dirs) but misnamed; fixed to suffix the captured base, plus a
+  two-level cross-JVM regression test. The unit suite missed it (only spilled one level); the live
+  four-shell test surfaced it.
 
 ## Next up
 
-- **Commit + push this repo and open its PR** (client 0003 implementation + API cleanup + doc
-  refresh). This is the linchpin the toolkit/bootstrap PRs pair with.
+- **Commit this session's working tree** (spill fix + test cleanup) and **open this repo's PR** — the
+  linchpin the toolkit/bootstrap PRs pair with.
 - Optional: full toolkit reactor build (`mvn install`) to confirm nothing downstream of
-  `core/configuration` breaks — only that module + its deps were built so far.
+  `core/configuration` breaks (only that module + deps built so far).
 - Then the deferred deployment-config items below.
 
-Design detail lives in [ADR 0003](../decisions/0003-shared-per-jvm-cache.md); the build steps (now
-executed) are in the [workplan](LSSTCCS-3029-shared-per-jvm-cache.md).
+## Backlog
+
+- **Cosmetic SEVERE on shutdown (has a JIRA).** When the bootstrap mounts an external `ccs://` FS
+  that is never closed, no `Cache.close()` runs, so the global logger-off workaround
+  (`Cache.close()` sets `IndexedDiskCache` logging to OFF) never fires and JCS's own shutdown hook
+  logs `Region [default] : Not alive and dispose was called`. Data still spools; lock released on
+  exit. Cosmetic. Real fix: silence at the source (constructor / logging config) rather than as a
+  close-time side effect, or close bootstrap mounts on shutdown.
 
 ## Deferred (deployment-config, not code)
 
-- Per-agent-category default policy: role agents (unique, reproducible names) reattach with a
-  persistent disk cache; `ccs-shell`/`ccs-console` (unique, non-reproducible names) don't
-  reattach — decide `OFFLINE` vs `WHEN_POSSIBLE` and memory vs disk per category.
+- Per-agent-category default policy: role agents (stable, reproducible app names) reattach with a
+  persistent disk cache; `ccs-shell`/`ccs-console` (same app name across instances → collide + spill)
+  don't reattach — decide `OFFLINE` vs `WHEN_POSSIBLE` and memory vs disk per category.
 - Bootstrap default `defaultEnvironment` values/location for base and summit.

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -5,26 +5,33 @@
 
 ## State
 
-Branch `LSSTCCS-3029` has the ADR 0001 + 0002 work implemented, tested (35 client tests pass),
-and committed (`666f59c` isolation, `7ecd9ea` cascade, `781dcb9` ~ expansion, `4a19526` docs).
+**ADR 0003 is implemented across all three repos** (one shared cache per JVM; cache location + spill
+flag JVM-global; caching policy per-mount; the per-FS `cacheLocation()`/`ignoreLockedCache()` builder
+methods removed and replaced by a set-once `setCacheLocation(Path)` that also backs the CLI's
+`--cacheDir`).
 
-A design session with Tony reversed direction on 0001. The 2026-07-21 brainstorm settled the full
-design: **one shared cache per JVM**, cache location + spill flag go **JVM-global**, caching policy
-stays per-mount. Now recorded in [ADR 0003](../decisions/0003-shared-per-jvm-cache.md) (proposed,
-amends [0002](../decisions/0002-option-resolution-cascade.md)). No 0003 code written yet — the branch
-still contains the 0001 isolation code that 0003 unwinds.
+- **rest-file-server (this repo):** 0003 implemented + the API cleanup, `mvn install` green
+  (client 42 tests, war 9, cli builds). **Working tree is uncommitted** — the docs are committed
+  through `ae22a5c` (that commit is also unpushed); the 0003 client/cli implementation + this doc
+  refresh are not yet committed. No PR opened yet.
+- **bootstrap:** `<app|default>` token + shipped `defaultEnvironment` line — committed, pushed,
+  PR #20.
+- **toolkit:** client bumped to 1.1.10-SNAPSHOT + `RemoteFileServer` cleanup — committed, pushed,
+  PR #316.
 
-The **bootstrap half is done**: the `<app|default>` token + `getJavaOpts` resolution and the shipped
-`defaultEnvironment` line are implemented, tested, and in PR
-(`org-lsst-ccs-bootstrap` PR #20, branch `LSSTCCS-3029`). It's runtime-coupled only — no build
-dependency, does not block this client work (see the workplan's deployment section).
+The three are coupled only at deployment (no build dependency on each other's SNAPSHOTs beyond the
+toolkit's declared versions); roll out together.
 
 ## Next up
 
-**Build ADR 0003 per the workplan:**
-[LSSTCCS-3029 — One shared cache per JVM](LSSTCCS-3029-shared-per-jvm-cache.md). It holds the full
-step-by-step (client-only for correctness; toolkit is non-blocking cleanup). The design decisions
-live in ADR 0003; this workplan is the how, and is the doc to share with Tony.
+- **Commit + push this repo and open its PR** (client 0003 implementation + API cleanup + doc
+  refresh). This is the linchpin the toolkit/bootstrap PRs pair with.
+- Optional: full toolkit reactor build (`mvn install`) to confirm nothing downstream of
+  `core/configuration` breaks — only that module + its deps were built so far.
+- Then the deferred deployment-config items below.
+
+Design detail lives in [ADR 0003](../decisions/0003-shared-per-jvm-cache.md); the build steps (now
+executed) are in the [workplan](LSSTCCS-3029-shared-per-jvm-cache.md).
 
 ## Deferred (deployment-config, not code)
 

--- a/docs/workplans/HANDOFF.md
+++ b/docs/workplans/HANDOFF.md
@@ -1,0 +1,40 @@
+# HANDOFF
+
+- Anchor: branch `LSSTCCS-3029`, as of the commit that carries this file.
+- On resume: `git log --oneline main..HEAD` to see what moved on the branch.
+
+## State
+
+Per-file-system cache isolation (LSSTCCS-3029) is **implemented and tested** — not yet
+merged. Each `ccs://` file system now gets its own JCS region and its own disk directory,
+keyed off a stable hash of `getFullURI()`. `CACHE_LOCATION` is now a *base* directory; each
+server caches under `<base>/<key>`. Changes: `Cache.java` (per-server key, region, disk
+subdir, `getRegion()`/`getDiskCacheLocation()` getters), `RestFileSystem.java` (passes
+`getFullURI()` to `Cache`), `disk.ccf` (tokenized `%REGION%`/`%AUX%`), and `CachingTest.java`
+(rewrote `cacheLockTest` for same-server contention, added `multiServerSharedBaseTest`).
+
+All 32 client tests pass. The ADR's main risk is resolved: repeated `ccm.configure(props)`
+on the singleton **accumulates** regions rather than resetting them.
+
+Background from the investigation: previously every `Cache` used the JVM-global
+`CompositeCacheManager` singleton with the hardcoded region `"default"` / auxiliary `"DC"`,
+so all file systems shared one region, disk store, and memory budget — and two
+`MEMORY_AND_DISK` mounts sharing a `CACHE_LOCATION` collided on the disk lock. See ADR 0001
+and workplan LSSTCCS-3029.
+
+## Next up
+
+- Review + merge LSSTCCS-3029.
+- Then tackle the default-policy / wiring gap below (isolation is now safe under multiple
+  mounts, so the sequencing precondition is met).
+
+## Backlog / deferred
+
+- **Default policy at bootstrap + system-property wiring gap.** We want bootstrap mounts to
+  default to `MEMORY_AND_DISK`, but `RestFileSystemProvider.newFileSystem` (`:66-69`) sets
+  `env = NO_ENV` (a non-null empty map) when the caller passes `null`, which shadows the
+  `DEFAULT_ENV_PROPERTY` system property — `RestFileSystemOptionsHelper` only consults the
+  property when `env` is null (`:31-37`), so the property is effectively dead on the normal
+  path. Needs a decision on resolution order (per-key cascade vs. coarse first-non-empty)
+  and where to resolve it. Graduate to its own ADR + workplan when it firms up. Sequencing:
+  the isolation work (3029) should land first so the default is safe under multiple mounts.

--- a/docs/workplans/LSSTCCS-3029-per-file-system-cache-isolation.md
+++ b/docs/workplans/LSSTCCS-3029-per-file-system-cache-isolation.md
@@ -1,0 +1,83 @@
+# LSSTCCS-3029 — Per-file-system cache isolation
+
+- Branch: `LSSTCCS-3029`
+- ADR: [0001 — Per-file-system cache isolation](../decisions/0001-per-file-system-cache-isolation.md)
+- Line numbers anchored to commit `058fe1a`; use `git show 058fe1a:<path>` if they look off.
+
+## Goal
+
+Each `ccs://` remote file system gets its own JCS region and its own disk directory,
+auto-derived from a stable per-server key, so multiple bootstrap mounts can all use
+`MEMORY_AND_DISK` without lock collisions or a shared region.
+
+## Steps
+
+### 1. Per-server key
+
+Add a helper that turns `RestFileSystem.getFullURI().toString()` into a filesystem- and
+JCS-safe token: sanitize host/port/path to `[A-Za-z0-9_]` and append a short stable hash
+(first 8 hex of SHA-256 of the full URI) to disambiguate sanitized-equal URIs. Must be
+deterministic across restarts. Keep it inside `Cache` unless it needs reuse.
+
+- `client/.../implementation/Cache.java`
+
+### 2. Pass the key into the cache
+
+`RestFileSystem` constructs `new Cache(options)` at `RestFileSystem.java:69`. Change to
+`new Cache(options, getFullURI())` and thread the URI through the `Cache` constructor
+(currently `Cache(RestFileSystemOptionsHelper)`, `Cache.java:45`). `getFullURI()` is
+available at that point (uri/mountPoint set at `RestFileSystem.java:64-65`).
+
+- `client/.../implementation/RestFileSystem.java`
+- `client/.../implementation/Cache.java`
+
+### 3. Per-server disk directory (layer 1)
+
+Reinterpret `CACHE_LOCATION` as a base directory. In `Cache`, join `<base>/<key>` to form
+the per-server disk dir before the lock/`DiskPath` logic (`Cache.java:62-93`).
+`getDiskCacheLocation()` in `RestFileSystemOptionsHelper` (`:90`) still returns the base
+unchanged; the subdir join happens in `Cache`. The lock then guards `<base>/<key>/lockFile`,
+distinct per server. `ALLOW_ALTERNATE_CACHE_LOCATION` behavior is unchanged.
+
+- `client/.../implementation/Cache.java`
+
+### 4. Per-server JCS region + auxiliary (layer 2)
+
+Tokenize the two resource files so the region name, auxiliary name, and disk path are
+placeholders (e.g. `%REGION%`, `%AUX%`, `%DISKPATH%`) instead of the hardcoded
+`default` / `DC` / `${user.home}/jcs_swap`:
+
+- `client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/memory.ccf`
+- `client/src/main/resources/org/lsst/ccs/rest/file/server/client/implementation/disk.ccf`
+
+In `Cache`, load the template, substitute the per-server key into the tokens, then
+`ccm.configure(props)` and `map = JCS.getInstance("<region-key>")` (replacing the
+hardcoded `"default"` at `Cache.java:97`). The `CompositeCacheManager` stays a singleton
+hosting N regions.
+
+- `client/.../implementation/Cache.java`
+
+## Tests
+
+- **Rewrite `cacheLockTest`** (`CachingTest.java:172-209`). Current premise (two servers,
+  same `CACHE_LOCATION` → second fails "in use") is reversed by this change: with
+  per-server keying both should now succeed against a shared base. Assert that, and add a
+  case that still proves the lock fires for genuine same-directory contention (two `Cache`
+  instances on the identical resolved dir).
+- **New isolation test** (`CachingTest` or new `CacheIsolationTest`): two `TestServer`s,
+  `MEMORY_AND_DISK` + shared base `CACHE_LOCATION`. Assert both construct, `getCache()` on
+  each resolves a different region/disk dir, and an entry cached for one server is absent
+  from the other's cache (extend the `cache.getEntry(...)` pattern at `CachingTest.java:68`).
+- **`ccm.configure` accumulation check**: the isolation test doubles as the guard for the
+  main risk — confirm the second region does not reset the first. If it does, switch to
+  programmatic region creation per the ADR.
+
+## Verify
+
+- `mvn -pl war,client -am install` (client tests need the war test-jar), or
+  `mvn -Dtest=CachingTest test -pl client` for the focused loop.
+
+## Risks
+
+- `ccm.configure(props)` repeated on the singleton — see accumulation check above.
+- `CACHE_LOCATION` leaf → base semantic change; review deployed config before release.

--- a/docs/workplans/LSSTCCS-3029-per-file-system-cache-isolation.md
+++ b/docs/workplans/LSSTCCS-3029-per-file-system-cache-isolation.md
@@ -4,6 +4,10 @@
 - ADR: [0001 — Per-file-system cache isolation](../decisions/0001-per-file-system-cache-isolation.md)
 - Line numbers anchored to commit `058fe1a`; use `git show 058fe1a:<path>` if they look off.
 
+> **Done and committed, but largely superseded.** This built ADR 0001;
+> [ADR 0003](../decisions/0003-shared-per-jvm-cache.md) now reverses it. See HANDOFF for the
+> current plan. Kept for history.
+
 ## Goal
 
 Each `ccs://` remote file system gets its own JCS region and its own disk directory,

--- a/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
+++ b/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
@@ -36,18 +36,24 @@ cleanup (step 6), not a prerequisite.
 
 The global config arrives via the `DEFAULT_ENV_PROPERTY` system property
 (`org.lsst.ccs.rest.file.client.defaultEnvironment`) — a JSON map with `CacheOptions`,
-`CacheLocation`, and optionally `CacheFallbackLocation`:
+`CacheLocation`, and `CacheFallbackLocation`. It must be set **at JVM startup** (resolved once, before
+the first mount), not from app code that runs after a file system exists.
+
+**Preferred: the CCS bootstrap** sets it while launching the JVM, using an `<app|default>` token that
+resolves to the agent name so role agents reattach across restarts. The shipped bootstrap line is:
 
 ```
--Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/focal-plane"}'
+system.property.org.lsst.ccs.rest.file.client.defaultEnvironment={"CacheOptions":"MEMORY_AND_DISK","CacheFallbackLocation":true,"CacheLocation":"~/ccs/cache/<app|default>"}
 ```
 
-It must be set **at JVM startup** (resolved once, before the first mount) — not from app code that
-runs after a file system exists. **Preferred: the CCS bootstrap** sets it while launching the JVM,
-injecting a unique per-host location (agent name) so role agents reattach across restarts; it already
-owns JVM launch and knows the agent identity. App/launch-file `-D` works for non-agent JVMs, but then
-the operator owns location uniqueness. Setting neither falls to `~/ccs/cache/default` (shared,
-non-reattaching). See [ADR 0003 §2](../decisions/0003-shared-per-jvm-cache.md) for details.
+App/launch-file `-D` works for non-agent JVMs, but then the operator owns location uniqueness. Setting
+neither falls to `~/ccs/cache/default`. See [ADR 0003 §2](../decisions/0003-shared-per-jvm-cache.md)
+and [bootstrap ADR 0001](../../../org-lsst-ccs-bootstrap/docs/decisions/0001-substitution-tokens-in-java-opts.md).
+
+**No dependency on the bootstrap for this work.** The client only reads the property and does not
+care how it was produced; there is no build dependency, and the client tests set the config directly
+(backdoor / env). The two repos are coupled only at deployment (roll out together), so the bootstrap
+change does **not** block or alter the implementation steps below.
 
 ## Steps
 

--- a/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
+++ b/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
@@ -15,17 +15,18 @@ spill flag JVM-global** (resolved once, before any file system is created), keep
 per-mount**, and restore the lock to a **cross-JVM-only** guard where same-JVM mounts share instead
 of colliding.
 
-This is a **client-only** change. **No changes are required on the toolkit side**: the client stops
-reading the per-FS `CacheLocation`/`ignoreLockedCache` values, so the toolkit's existing calls become
-inert no-ops on upgrade — it keeps working unchanged. Removing those now-dead calls is optional
-cleanup (step 6), not a prerequisite.
+This is a **client + coordinated toolkit** change. The client stops reading the per-FS
+`CacheLocation`/`ignoreLockedCache` values and **removes** those builder methods, so the toolkit must
+rebuild against the new client and drop those calls (step 6) — a required coordinated change, done in
+the toolkit's LSSTCCS-3029 PR. It is runtime/deployment-coupled, not a build dependency of this repo.
 
 ## Design summary (see ADR 0003 for the why)
 
 - **One cache per JVM.** Region `default`, single disk store at the resolved location.
-- **Global config.** `CacheLocation` + `CacheFallbackLocation` resolved once: test backdoor →
-  `DEFAULT_ENV_PROPERTY` JSON → built-in default `~/ccs/cache/default`. Per-FS `env` for these two
-  is ignored; builder setters deprecated + no-op.
+- **Global config.** `CacheLocation` + `CacheFallbackLocation` resolved once: programmatic override
+  (`setCacheLocation(Path)`, set-once; used by the CLI's `--cacheDir`) → `DEFAULT_ENV_PROPERTY` JSON
+  → built-in default `~/ccs/cache/default`. Per-FS `env` for these two is ignored; the per-FS builder
+  setters `cacheLocation()`/`ignoreLockedCache()` are removed. (Tests seed the globals via a backdoor.)
 - **Per-FS policy.** `CacheOptions` (default `NONE`) and `CacheFallback` still flow the 0002 cascade.
 - **Lock.** Three `tryLock()` outcomes on `<loc>/lockFile`: lock → own it; overlap-exception →
   another mount in *this* JVM → share (no lock); `null` → another process → spill `<loc>-N` (if the
@@ -70,15 +71,15 @@ in `memory.ccf`. Keep `disk.ccf`'s `DiskPath` unset (set programmatically in `Ca
 `CacheLocation` and `CacheFallbackLocation` become JVM-global, resolved before the first FS:
 
 - Add a global resolver (a static holder) that returns the location and spill flag from, in order:
-  a package-private test backdoor → `DEFAULT_ENV_PROPERTY` JSON → built-in default
-  `~/ccs/cache/default`. Move the leading-`~` + `Path.normalize()` handling
-  (`RestFileSystemOptionsHelper.expandTilde`/`getDiskCacheLocation`, `:117-150`) into this resolver
-  and apply it to the built-in default too.
-- Stop reading these two keys from the per-FS merged env, so a per-FS `cacheLocation()` /
-  `ignoreLockedCache()` value is inert (this is what makes the toolkit call a no-op without a rebuild).
-- Deprecate `RestFileSystemOptions.Builder.cacheLocation()` and `ignoreLockedCache()`
-  (`RestFileSystemOptions.java:172`, and the `cacheLocation` builder method) as no-ops; add the
-  package-private backdoor setter(s) that relocate the globals for tests, resettable per test.
+  a programmatic override → `DEFAULT_ENV_PROPERTY` JSON → built-in default `~/ccs/cache/default`.
+  Move the leading-`~` + `Path.normalize()` handling into this resolver and apply it to the built-in
+  default too. The override pins location only; the spill flag always resolves from the property.
+- Stop reading these two keys from the per-FS merged env, and **remove** the per-FS builder methods
+  `RestFileSystemOptions.Builder.cacheLocation(File/Path)` and `ignoreLockedCache()` (only this repo
+  and the toolkit called them).
+- Add a public `RestFileSystemOptions.setCacheLocation(Path)` (bridged via `RestFileSystemProvider`)
+  that pins the override, allowed only before the cache is configured (else `IllegalStateException`).
+  Add a package-private backdoor setter/reset for tests.
 
 - `client/.../implementation/RestFileSystemOptionsHelper.java`
 - `client/.../RestFileSystemOptions.java`
@@ -140,12 +141,13 @@ Document the JVM-scoped-`FileLock` asymmetry and the release-on-acquiring-mount 
 
 - `client/src/test/.../implementation/CachingTest.java`, `SpeedTest.java`, `VersionedFileTest.java`
 
-### 6. Toolkit — no changes needed (optional cleanup)
+### 6. Toolkit — required coordinated rebuild
 
-**Nothing must change in the toolkit.** On client upgrade, `RemoteFileServer.createFileSystem`'s
-`.cacheLocation(...)` and `.ignoreLockedCache(true)` (`core/configuration/.../RemoteFileServer.java:157,159`)
-become inert no-ops — the toolkit keeps working unchanged. Removing those dead calls is optional
-cleanup, done after the client work. Toolkit is version-coupled (client 1.1.8; this is 1.1.10-SNAPSHOT).
+Because the per-FS builder methods are **removed**, the toolkit must rebuild against the new client:
+bump `org-lsst-ccs-rest-file-server-client` to 1.1.10-SNAPSHOT and drop
+`RemoteFileServer.createFileSystem`'s `.cacheLocation(...)` / `.ignoreLockedCache(true)` calls (plus
+the now-dead per-service `cacheDir`). Done in the toolkit's LSSTCCS-3029 PR. Version-coupled at
+deployment (roll out with the new client + bootstrap), not a build dependency of this repo.
 
 ## Verify
 

--- a/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
+++ b/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
@@ -128,14 +128,19 @@ Document the JVM-scoped-`FileLock` asymmetry and the release-on-acquiring-mount 
   assertion.)
 - **Cross-JVM guard** (surefire subprocess): a helper `main` in test sources reuses the real `Cache`
   to grab the lock on a location, prints a readiness marker, blocks. Parent (globals via backdoor)
-  asserts: spill flag on → second `Cache` resolves `<loc>-1`; flag off → "in use". Knobs: readiness
-  handshake + timeout, forced teardown (`destroyForcibly` in `finally`), helper self-terminate
-  safety timeout. Linux-only; revisit if CI flakes.
+  asserts: spill flag on → second `Cache` resolves `<loc>-1`; flag off → "in use". A second case
+  (`spillsToFlatSiblingsWhenWalkingPastMultipleLocks`) launches **two** holder JVMs (on `cache` and
+  `cache-1`) so the `Cache` under test must land on `cache-2` — a regression guard for the
+  spill-naming bug (below). Knobs: readiness handshake + timeout, forced teardown (`destroyForcibly`),
+  helper self-terminate safety timeout. Linux-only; revisit if CI flakes.
 - **Per-FS location inert:** assert a per-FS `cacheLocation()` does **not** change the resolved
   location (proves the toolkit call is dead).
 - **Migrate** `CachingTest`/`SpeedTest`/`VersionedFileTest` off per-FS `cacheLocation(tempDir)` onto
   the backdoor; ensure the backdoor is reset after each test (static-leak caveat, cf.
-  `DefaultEnvTest.clearDefaults`).
+  `DefaultEnvTest.clearDefaults`). These tests (plus `CacheLockCrossJvmTest`) now take a JUnit 5
+  `@TempDir Path` instead of `Files.createTempDirectory("rfs")`, so JUnit deletes each cache tree
+  after the test and `/tmp` no longer accumulates `rfs*` dirs; `SpeedTest` was migrated JUnit 4 →
+  Jupiter for this.
 - Rewrite `cacheLockTest` (`CachingTest.java:236-268`) — its in-JVM "in use" premise is now the
   *share* path; the cross-JVM assertion moves to the subprocess test.
 
@@ -155,6 +160,15 @@ deployment (roll out with the new client + bootstrap), not a build dependency of
   `mvn -Dtest=CachingTest test -pl client` for the focused loop.
 - Update the [toolkit cache-compatibility guide](../guides/toolkit-cache-compatibility.md) to the
   0003 model in the same PR (it currently describes the 0001 build).
+- Live runtime verification against the dev server (2026-07-21): warm-start offline + reattach,
+  one shared region with mixed `OFFLINE`/`WHEN_POSSIBLE` mounts, spill, and stale-lock reclaim.
+  Recorded in the guide's Verification section.
+
+**Bug found & fixed during verification.** The spill loop (`Cache.lockCacheLocation`) suffixed the
+already-mutated candidate rather than the pristine base, so a second spill compounded to
+`<base>-1-2` (and `<base>-1-2-3`) instead of flat `<base>-2`, `-3`. Safe (each still got a distinct,
+exclusively-locked dir) but wrongly named. Fixed to suffix the captured base; covered by the new
+two-level cross-JVM test. The unit suite missed it because it only spilled one level.
 
 ## Risks
 

--- a/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
+++ b/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
@@ -144,7 +144,7 @@ Document the JVM-scoped-`FileLock` asymmetry and the release-on-acquiring-mount 
 ### 6. Toolkit — required coordinated rebuild
 
 Because the per-FS builder methods are **removed**, the toolkit must rebuild against the new client:
-bump `org-lsst-ccs-rest-file-server-client` to 1.1.10-SNAPSHOT and drop
+bump `org-lsst-ccs-rest-file-server-client` to 1.1.11 and drop
 `RemoteFileServer.createFileSystem`'s `.cacheLocation(...)` / `.ignoreLockedCache(true)` calls (plus
 the now-dead per-service `cacheDir`). Done in the toolkit's LSSTCCS-3029 PR. Version-coupled at
 deployment (roll out with the new client + bootstrap), not a build dependency of this repo.

--- a/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
+++ b/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
@@ -1,0 +1,145 @@
+# LSSTCCS-3029 — One shared cache per JVM (ADR 0003)
+
+- Branch: `LSSTCCS-3029`
+- ADR: [0003 — One shared cache per JVM, global cache config, policy in the file system](../decisions/0003-shared-per-jvm-cache.md)
+  (amends [0002](../decisions/0002-option-resolution-cascade.md))
+- Line numbers anchored to commit `3d756fa`; use `git show 3d756fa:<path>` if they look off.
+- Supersedes the [0001 workplan](LSSTCCS-3029-per-file-system-cache-isolation.md), which built the
+  isolation this now unwinds.
+
+## Goal
+
+Collapse the per-file-system cache isolation from ADR 0001 back to **one shared cache per JVM**:
+one JCS `default` region and one disk store, shared by every mount. Make the cache **location and
+spill flag JVM-global** (resolved once, before any file system is created), keep **caching policy
+per-mount**, and restore the lock to a **cross-JVM-only** guard where same-JVM mounts share instead
+of colliding.
+
+This is a **client-only** change. **No changes are required on the toolkit side**: the client stops
+reading the per-FS `CacheLocation`/`ignoreLockedCache` values, so the toolkit's existing calls become
+inert no-ops on upgrade — it keeps working unchanged. Removing those now-dead calls is optional
+cleanup (step 6), not a prerequisite.
+
+## Design summary (see ADR 0003 for the why)
+
+- **One cache per JVM.** Region `default`, single disk store at the resolved location.
+- **Global config.** `CacheLocation` + `CacheFallbackLocation` resolved once: test backdoor →
+  `DEFAULT_ENV_PROPERTY` JSON → built-in default `~/ccs/cache/default`. Per-FS `env` for these two
+  is ignored; builder setters deprecated + no-op.
+- **Per-FS policy.** `CacheOptions` (default `NONE`) and `CacheFallback` still flow the 0002 cascade.
+- **Lock.** Three `tryLock()` outcomes on `<loc>/lockFile`: lock → own it; overlap-exception →
+  another mount in *this* JVM → share (no lock); `null` → another process → spill `<loc>-N` (if the
+  global spill flag is set) or fail "in use". Flag defaults `false`.
+- **Policy-free `Cache`.** Expiry decision moves to the per-mount `CacheRequestFilter`.
+
+## Steps
+
+### 1. Restore `.ccf` templates (revert 0001)
+
+Undo the `%REGION%`/`%AUX%` tokenization; region `default`, auxiliary `DC`. Set `MaxObjects=2500`
+in `memory.ccf`. Keep `disk.ccf`'s `DiskPath` unset (set programmatically in `Cache`).
+
+- `client/src/main/resources/.../implementation/memory.ccf`
+- `client/src/main/resources/.../implementation/disk.ccf`
+
+### 2. Global cache-config resolution
+
+`CacheLocation` and `CacheFallbackLocation` become JVM-global, resolved before the first FS:
+
+- Add a global resolver (a static holder) that returns the location and spill flag from, in order:
+  a package-private test backdoor → `DEFAULT_ENV_PROPERTY` JSON → built-in default
+  `~/ccs/cache/default`. Move the leading-`~` + `Path.normalize()` handling
+  (`RestFileSystemOptionsHelper.expandTilde`/`getDiskCacheLocation`, `:117-150`) into this resolver
+  and apply it to the built-in default too.
+- Stop reading these two keys from the per-FS merged env, so a per-FS `cacheLocation()` /
+  `ignoreLockedCache()` value is inert (this is what makes the toolkit call a no-op without a rebuild).
+- Deprecate `RestFileSystemOptions.Builder.cacheLocation()` and `ignoreLockedCache()`
+  (`RestFileSystemOptions.java:172`, and the `cacheLocation` builder method) as no-ops; add the
+  package-private backdoor setter(s) that relocate the globals for tests, resettable per test.
+
+- `client/.../implementation/RestFileSystemOptionsHelper.java`
+- `client/.../RestFileSystemOptions.java`
+
+### 3. Collapse `Cache` to one shared cache + cross-JVM lock (revert 0001 + new share logic)
+
+`Cache` constructor back to `Cache(RestFileSystemOptionsHelper)` — drop the `URI serverURI` param,
+`regionKey`, `shortHash`, per-server subdir/`region` fields, and `getRegion()`. Region is `default`,
+DiskPath is the resolved global location leaf.
+
+Rewrite the lock loop for the three outcomes (ADR 0003 §3):
+- `tryLock()` → non-null: keep the lock, `break`.
+- `OverlappingFileLockException`: this JVM already owns the location → share (no lock; close the
+  probe channel), record the location, `break`. Independent of the spill flag.
+- `tryLock()` → `null`: another process → if the global spill flag set, walk to `<loc>-N`; else
+  throw "in use".
+
+Document the JVM-scoped-`FileLock` asymmetry and the release-on-acquiring-mount wart inline
+(concise). Keep a resolved-disk-location accessor for tests; drop `getRegion()`.
+
+- `client/.../implementation/Cache.java` (`:58-179`)
+- `client/.../implementation/RestFileSystem.java` (`new Cache(options, getFullURI())` at `:69`)
+
+### 4. Move caching policy out of `Cache` into the filter (ADR 0003 §4)
+
+- `Cache.getEntry(uri)` → `return map.get(uri)` (no expiry stamping). Delete the `cacheFallback`
+  field, `setCacheFallbackOption`, `doEntriesExpire` (`Cache.java:40,125,181-195`).
+- Delete `CacheEntry.isExpired`/`setIsExpired` and the `isExpired` field (`Cache.java:229,267-273`).
+  Removing the serialized field is read-compatible with old disk entries; no `serialVersionUID` bump.
+- `CacheRequestFilter` gains a per-mount `doEntriesExpire` flag; `filter()`'s `!entry.isExpired()`
+  becomes `!doEntriesExpire` (`CacheRequestFilter.java:44-52`).
+- `RestFileSystem` computes both flags next to the existing `cacheOnly` and passes them
+  (`RestFileSystem.java:70`): `cacheOnly = offline || fallback==ALWAYS`,
+  `doEntriesExpire = fallback != WHEN_POSSIBLE`.
+- `SpeedTest`'s two `getCache().setCacheFallbackOption(...)` calls (`SpeedTest.java:38,52`) move to a
+  file-system-level hook that re-registers/updates the filter's policy.
+
+- `client/.../implementation/Cache.java`, `CacheRequestFilter.java`, `RestFileSystem.java`
+- `client/src/test/.../implementation/SpeedTest.java`
+
+### 5. Tests
+
+- **Share test** (replaces `multiServerSharedBaseTest`, `CachingTest.java:174-228`): two `TestServer`s
+  in one JVM on the global location (set via backdoor). Assert both construct, resolve the **same**
+  disk dir, and an entry cached via one mount is visible through the other. (Inverts 0001's isolation
+  assertion.)
+- **Cross-JVM guard** (surefire subprocess): a helper `main` in test sources reuses the real `Cache`
+  to grab the lock on a location, prints a readiness marker, blocks. Parent (globals via backdoor)
+  asserts: spill flag on → second `Cache` resolves `<loc>-1`; flag off → "in use". Knobs: readiness
+  handshake + timeout, forced teardown (`destroyForcibly` in `finally`), helper self-terminate
+  safety timeout. Linux-only; revisit if CI flakes.
+- **Per-FS location inert:** assert a per-FS `cacheLocation()` does **not** change the resolved
+  location (proves the toolkit call is dead).
+- **Migrate** `CachingTest`/`SpeedTest`/`VersionedFileTest` off per-FS `cacheLocation(tempDir)` onto
+  the backdoor; ensure the backdoor is reset after each test (static-leak caveat, cf.
+  `DefaultEnvTest.clearDefaults`).
+- Rewrite `cacheLockTest` (`CachingTest.java:236-268`) — its in-JVM "in use" premise is now the
+  *share* path; the cross-JVM assertion moves to the subprocess test.
+
+- `client/src/test/.../implementation/CachingTest.java`, `SpeedTest.java`, `VersionedFileTest.java`
+
+### 6. Toolkit — no changes needed (optional cleanup)
+
+**Nothing must change in the toolkit.** On client upgrade, `RemoteFileServer.createFileSystem`'s
+`.cacheLocation(...)` and `.ignoreLockedCache(true)` (`core/configuration/.../RemoteFileServer.java:157,159`)
+become inert no-ops — the toolkit keeps working unchanged. Removing those dead calls is optional
+cleanup, done after the client work. Toolkit is version-coupled (client 1.1.8; this is 1.1.10-SNAPSHOT).
+
+## Verify
+
+- `mvn -pl war,client -am install` (client tests need the war test-jar), or
+  `mvn -Dtest=CachingTest test -pl client` for the focused loop.
+- Update the [toolkit cache-compatibility guide](../guides/toolkit-cache-compatibility.md) to the
+  0003 model in the same PR (it currently describes the 0001 build).
+
+## Risks
+
+- **Shared-region behavior:** confirm all mounts genuinely resolve the same `default` region and disk
+  store and that entries are cross-visible (share test covers this).
+- **Subprocess test flakiness** in CI — mitigated by the knobs; fall back to the share-path-only
+  coverage if it proves unstable.
+- **Backdoor leak:** a test that forgets to reset the global would pollute others — enforce reset.
+
+## Out of scope (deferred, deployment-config — see HANDOFF)
+
+Per-agent-category default policy (`OFFLINE` vs `WHEN_POSSIBLE`, memory vs disk); bootstrap
+`defaultEnvironment` values/location for base and summit.

--- a/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
+++ b/docs/workplans/LSSTCCS-3029-shared-per-jvm-cache.md
@@ -32,6 +32,23 @@ cleanup (step 6), not a prerequisite.
   global spill flag is set) or fail "in use". Flag defaults `false`.
 - **Policy-free `Cache`.** Expiry decision moves to the per-mount `CacheRequestFilter`.
 
+## How the global config is delivered (deployment)
+
+The global config arrives via the `DEFAULT_ENV_PROPERTY` system property
+(`org.lsst.ccs.rest.file.client.defaultEnvironment`) — a JSON map with `CacheOptions`,
+`CacheLocation`, and optionally `CacheFallbackLocation`:
+
+```
+-Dorg.lsst.ccs.rest.file.client.defaultEnvironment='{"CacheOptions":"MEMORY_AND_DISK","CacheLocation":"~/ccs/cache/focal-plane"}'
+```
+
+It must be set **at JVM startup** (resolved once, before the first mount) — not from app code that
+runs after a file system exists. **Preferred: the CCS bootstrap** sets it while launching the JVM,
+injecting a unique per-host location (agent name) so role agents reattach across restarts; it already
+owns JVM launch and knows the agent identity. App/launch-file `-D` works for non-agent JVMs, but then
+the operator owns location uniqueness. Setting neither falls to `~/ccs/cache/default` (shared,
+non-reattaching). See [ADR 0003 §2](../decisions/0003-shared-per-jvm-cache.md) for details.
+
 ## Steps
 
 ### 1. Restore `.ccf` templates (revert 0001)


### PR DESCRIPTION
## Summary

This branch carries the full LSSTCCS-3029 client work. It landed in two design phases:

1. **ADR 0002** — per-key option resolution cascade (explicit env → programmatic default → `DEFAULT_ENV_PROPERTY` → hardcoded), plus `~`/normalize handling for a string `CacheLocation`.
2. **ADR 0003** (supersedes much of 0001, amends 0002) — **one shared cache per JVM**: cache **location + spill flag JVM-global**, **caching policy per-mount**, lock restored to a **cross-JVM-only** guard where same-JVM mounts share.

Client half of a three-repo feature (bootstrap PR #20, toolkit PR #316); coupled only at deployment — roll out together.

## Key changes (ADR 0003)

- **One cache per JVM** — `.ccf` reverted to region `default` / `DC`, `MaxObjects=2500`, `DiskPath` set programmatically; `Cache` shares one JCS region + disk store.
- **Global cache config** — `CacheLocation` + `CacheFallbackLocation` resolved once, before the first mount: set-once programmatic override → `DEFAULT_ENV_PROPERTY` JSON → built-in default `~/ccs/cache/default`. Per-FS `env` no longer supplies these two keys.
- **Cross-JVM lock** — three `tryLock()` outcomes on `<loc>/lockFile`: own it / share on `OverlappingFileLockException` (same JVM) / spill to `<loc>-N` or fail "in use" on `null` (another process). Documented inline.
- **Policy in the filter** — `Cache` is policy-free; the expiry decision moves to the per-mount `CacheRequestFilter`; `RestFileSystem` exposes a runtime `setCacheFallbackOption` hook.
- **API cleanup** — remove the per-FS builder methods `cacheLocation()` / `ignoreLockedCache()`; add public set-once `RestFileSystemOptions.setCacheLocation(Path)`; rewire the CLI `--cacheDir` to it. Keep the `CACHE_LOCATION` / `CacheFallbackLocation` constants (live JSON keys).

## Coordination note

The removed builder methods mean the **toolkit must rebuild** against this client (toolkit PR #316: bump to `1.1.10-SNAPSHOT` + drop the calls). Per-agent locations are delivered via the bootstrap `<app|default>` token (bootstrap PR #20). See the [toolkit cache-compatibility guide](docs/guides/toolkit-cache-compatibility.md).

## Tests

`mvn install` — **BUILD SUCCESS**, client **42 tests** / war **9** / cli builds, 0 failures. Includes a real-subprocess cross-JVM lock test, same-JVM share test, per-FS-inert / built-in-default / set-once-override tests, and existing caching tests migrated to the test backdoor.

## Docs

ADRs 0001–0003, the toolkit cache-compatibility guide, the workplan, and HANDOFF reflect the as-built state.